### PR TITLE
Disallow positional args

### DIFF
--- a/compass_sdk/compass.py
+++ b/compass_sdk/compass.py
@@ -66,6 +66,7 @@ class CompassMaxErrorRateExceeded(Exception):
 class CompassClient:
     def __init__(
         self,
+        *,
         index_url: str = "http://localhost:80",
         username: Optional[str] = None,
         password: Optional[str] = None,
@@ -106,7 +107,7 @@ class CompassClient:
         }
         logger.setLevel(logger_level.value)
 
-    def create_index(self, index_name: str):
+    def create_index(self, *, index_name: str):
         """
         Create an index in Compass
         :param index_name: the name of the index
@@ -119,7 +120,7 @@ class CompassClient:
             sleep_retry_seconds=DEFAULT_SLEEP_RETRY_SECONDS,
         )
 
-    def delete_index(self, index_name: str):
+    def delete_index(self, *, index_name: str):
         """
         Delete an index from Compass
         :param index_name: the name of the index
@@ -132,7 +133,7 @@ class CompassClient:
             sleep_retry_seconds=DEFAULT_SLEEP_RETRY_SECONDS,
         )
 
-    def delete_document(self, index_name: str, doc_id: str):
+    def delete_document(self, *, index_name: str, doc_id: str):
         """
         Delete a document from Compass
         :param index_name: the name of the index
@@ -147,7 +148,7 @@ class CompassClient:
             sleep_retry_seconds=DEFAULT_SLEEP_RETRY_SECONDS,
         )
 
-    def get_document(self, index_name: str, doc_id: str):
+    def get_document(self, *, index_name: str, doc_id: str):
         """
         Get a document from Compass
         :param index_name: the name of the index
@@ -176,6 +177,7 @@ class CompassClient:
 
     def add_context(
         self,
+        *,
         index_name: str,
         doc_id: str,
         context: Dict,
@@ -203,6 +205,7 @@ class CompassClient:
 
     def insert_doc(
         self,
+        *,
         index_name: str,
         doc: CompassDocument,
         max_retries: int = DEFAULT_MAX_RETRIES,
@@ -219,7 +222,7 @@ class CompassClient:
             index_name=index_name, docs=iter([doc]), max_retries=max_retries, sleep_retry_seconds=sleep_retry_seconds
         )
 
-    def insert_docs_batch(self, uuid: str, index_name: str):
+    def insert_docs_batch(self, *, uuid: str, index_name: str):
         """
         Insert a batch of parsed documents into an index in Compass
         :param uuid: the uuid of the batch
@@ -233,7 +236,7 @@ class CompassClient:
             sleep_retry_seconds=DEFAULT_SLEEP_RETRY_SECONDS,
         )
 
-    def batch_status(self, uuid: str):
+    def batch_status(self, *, uuid: str):
         """
         Get the status of a batch
         :param uuid: the uuid of the batch
@@ -251,6 +254,7 @@ class CompassClient:
 
     def insert_docs(
         self,
+        *,
         index_name: str,
         docs: Iterator[CompassDocument],
         max_chunks_per_request: int = DEFAULT_MAX_CHUNKS_PER_REQUEST,
@@ -374,6 +378,7 @@ class CompassClient:
 
     def search(
         self,
+        *,
         index_name: str,
         query: str,
         top_k: int = 10,


### PR DESCRIPTION
Suggesting this because it reduces surface area for breaking changes and also makes eventual auto-gen easier.