### PR TITLE
Removing admin from permissions

### DIFF
--- a/compass_sdk/types.py
+++ b/compass_sdk/types.py
@@ -44,7 +44,6 @@ class GroupUserDeleteResponse(BaseModel):
 class Permission(Enum):
     READ = "read"
     WRITE = "write"
-    ADMIN = "admin"
     ROOT = "root"
 
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR removes the `ADMIN` permission from the `Permission` enum in the `compass_sdk/types.py` file.

- The `ADMIN` permission is no longer available in the `Permission` enum.

<!-- end-generated-description -->