### PR TITLE
Adds $match capability in Compass (via WORD_MATCH)

### DIFF
--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -349,6 +349,7 @@ class SearchFilter(BaseModel):
         EQ = "$eq"
         LT_EQ = "$lte"
         GT_EQ = "$gte"
+        WORD_MATCH = "$wordMatch"
 
     field: str
     type: FilterType


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new `FilterType` called `WORD_MATCH` to the `compass_sdk/__init__.py` file.

- The `WORD_MATCH` filter type is added to the `FilterType` class.
- This new filter type is represented by the string `"$wordMatch"`.

<!-- end-generated-description -->