### PR TITLE
feat: add merge_groups_on_conflict

### DIFF
--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -373,6 +373,7 @@ class PutDocumentsInput(BaseModel):
 
     docs: List[Document]
     authorized_groups: Optional[List[str]] = None
+    merge_groups_on_conflict: Optional[bool] = False
 
 
 class BatchPutDocumentsInput(BaseModel):

--- a/compass_sdk/compass.py
+++ b/compass_sdk/compass.py
@@ -338,6 +338,7 @@ class CompassClient:
         skip_first_n_docs: int = 0,
         num_jobs: Optional[int] = None,
         authorized_groups: Optional[List[str]] = None,
+        merge_groups_on_conflict: Optional[bool] = False
     ) -> Optional[List[Dict[str, str]]]:
         """
         Insert multiple parsed documents into an index in Compass
@@ -362,7 +363,9 @@ class CompassClient:
             errors.extend(previous_errors)
             compass_docs: List[CompassDocument] = [compass_doc for compass_doc, _ in request_data]
             put_docs_input = PutDocumentsInput(
-                docs=[input_doc for _, input_doc in request_data], authorized_groups=authorized_groups
+                docs=[input_doc for _, input_doc in request_data],
+                authorized_groups=authorized_groups,
+                merge_groups_on_conflict=merge_groups_on_conflict
             )
 
             # It could be that all documents have errors, in which case we should not send a request


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request introduces a new feature to handle document conflicts during the insertion and put operations in the Compass SDK. The changes ensure that when inserting or putting documents, the system can now merge groups of documents when conflicts arise.

## Changes:
- A new parameter, `merge_groups_on_conflict`, is added to the `PutDocumentsInput` class in `__init__.py`. This parameter is set to `False` by default.
- The `insert_docs` function in `compass.py` now includes the `merge_groups_on_conflict` parameter in its signature, also set to `False` by default.
- When creating the `put_docs_input` in the `put_request` function, the `merge_groups_on_conflict` parameter is passed to the `PutDocumentsInput` class.

<!-- end-generated-description -->