### PR TITLE
Fix empty iterator due to wrong filtering expression

### DIFF
--- a/compass_sdk/parser.py
+++ b/compass_sdk/parser.py
@@ -217,7 +217,9 @@ class CompassParserClient:
             for doc in res.json()["docs"]:
                 if not doc.get("errors", []):
                     compass_doc = CompassDocument(**doc)
-                    additional_metadata = CompassParserClient._get_metadata(doc=doc, custom_context=custom_context)
+                    additional_metadata = CompassParserClient._get_metadata(
+                        doc=compass_doc, custom_context=custom_context
+                    )
                     compass_doc.content = {**compass_doc.content, **additional_metadata}
                     docs.append(compass_doc)
         else:

--- a/compass_sdk/parser.py
+++ b/compass_sdk/parser.py
@@ -213,10 +213,13 @@ class CompassParserClient:
         )
 
         if res.ok:
-            docs = [CompassDocument(**doc) for doc in res.json()["docs"] if doc.get("filebytes", False)]
-            for doc in docs:
-                additional_metadata = CompassParserClient._get_metadata(doc=doc, custom_context=custom_context)
-                doc.content = {**doc.content, **additional_metadata}
+            docs = []
+            for doc in res.json()["docs"]:
+                if not doc.get("errors", []):
+                    compass_doc = CompassDocument(**doc)
+                    additional_metadata = CompassParserClient._get_metadata(doc=doc, custom_context=custom_context)
+                    compass_doc.content = {**compass_doc.content, **additional_metadata}
+                    docs.append(compass_doc)
         else:
             docs = []
             logger.error(f"Error processing file: {res.text}")


### PR DESCRIPTION
<!-- begin-generated-description -->

The PR introduces changes to the `process_file` function in `compass_sdk/parser.py`, specifically the way it handles document processing and metadata retrieval.

- The `docs` list is now initialised as an empty list.
- The loop iterates over `res.json()["docs"]` instead of `docs`.
- A new condition checks for the absence of errors in each document before processing.
- The `CompassDocument` instance is created and assigned to `compass_doc` instead of directly appending to `docs`.
- The `additional_metadata` is retrieved and added to the `compass_doc.content` dictionary.
- The `compass_doc` is then appended to the `docs` list.

<!-- end-generated-description -->