### PR TITLE
Remove apply_pdf_rough_text_extraction and add pdf_parsing_strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9
+          - 3.11
 
     steps:
       - uses: actions/checkout@v4

--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -258,8 +258,8 @@ class DocumentFormat(str, Enum):
 
 
 class PDFParsingStrategy(StrEnum):
-    QuickText: str = "QuickText"
-    ImageToMarkdown: str = "ImageToMarkdown"
+    QuickText = "QuickText"
+    ImageToMarkdown = "ImageToMarkdown"
 
     @classmethod
     def _missing_(cls, value):

--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -1,11 +1,11 @@
 import logging
+import math
 import uuid
 from enum import Enum, StrEnum
 from os import getenv
 from typing import Annotated, Any, Dict, List, Optional, Union
 
-import math
-from pydantic import BaseModel, Field, PositiveInt, StringConstraints, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, StringConstraints
 
 from compass_sdk.constants import (
     COHERE_API_ENV_VAR,
@@ -319,6 +319,7 @@ class ParserConfig(BaseModel):
     horizontal_table_crop_margin: int = 100
 
     pdf_parsing_strategy: PDFParsingStrategy = PDFParsingStrategy.QuickText
+
 
 ### Document indexing
 

--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -1,10 +1,11 @@
 import logging
 import uuid
-from enum import Enum
+from enum import Enum, StrEnum
 from os import getenv
 from typing import Annotated, Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, PositiveInt, StringConstraints
+import math
+from pydantic import BaseModel, Field, PositiveInt, StringConstraints, ConfigDict
 
 from compass_sdk.constants import (
     COHERE_API_ENV_VAR,
@@ -256,7 +257,16 @@ class DocumentFormat(str, Enum):
         return cls.Markdown
 
 
-class ParserConfig(ValidatedModel):
+class PDFParsingStrategy(StrEnum):
+    QuickText: str = "QuickText"
+    ImageToMarkdown: str = "ImageToMarkdown"
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.QuickText
+
+
+class ParserConfig(BaseModel):
     """
     CompassParser configuration. Important parameters:
     :param parsing_strategy: the parsing strategy to use:
@@ -276,6 +286,11 @@ class ParserConfig(ValidatedModel):
 
     """
 
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="ignore",
+    )
+
     # CompassParser configuration
     logger_level: LoggerLevel = LoggerLevel.INFO
     parse_tables: bool = True
@@ -285,14 +300,14 @@ class ParserConfig(ValidatedModel):
     min_chars_per_element: int = DEFAULT_MIN_CHARS_PER_ELEMENT
     skip_infer_table_types: List[str] = SKIP_INFER_TABLE_TYPES
     parsing_strategy: ParsingStrategy = ParsingStrategy.Fast
-    parsing_model: ParsingModel = ParsingModel.Marker
+    parsing_model: ParsingModel = ParsingModel.YoloX_Quantized
 
     # CompassChunker configuration
     num_tokens_per_chunk: int = DEFAULT_NUM_TOKENS_PER_CHUNK
     num_tokens_overlap: int = DEFAULT_NUM_TOKENS_CHUNK_OVERLAP
     min_chunk_tokens: int = DEFAULT_MIN_NUM_TOKENS_CHUNK
     num_chunks_in_title: int = DEFAULT_MIN_NUM_CHUNKS_IN_TITLE
-    max_tokens_metadata: int = 1000
+    max_tokens_metadata: int = math.floor(num_tokens_per_chunk * 0.1)
     include_tables: bool = True
 
     # Formatting configuration
@@ -303,8 +318,7 @@ class ParserConfig(ValidatedModel):
     vertical_table_crop_margin: int = 100
     horizontal_table_crop_margin: int = 100
 
-    apply_pdf_rough_text_extraction: bool = False
-
+    pdf_parsing_strategy: PDFParsingStrategy = PDFParsingStrategy.QuickText
 
 ### Document indexing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.3.0"
+version = "0.3.1"
 authors = []
 description = "Compass SDK"
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request introduces changes to the `compass_sdk/__init__.py` file, focusing on the configuration of the `ParserConfig` class and the parsing strategy.

## Summary
The PR enhances the `ParserConfig class by adding a new `PDFParsingStrategy` enumeration, which defines parsing strategies for PDF documents. The `PDFParsingStrategy` enum includes two strategies: `QuickText` and `ImageToMarkdown`. The default strategy is set to `QuickText`.

Additionally, the `ParserConfig class is updated to inherit from `BaseModel` instead of `ValidatedModel`. This change allows for more flexible configuration options, as indicated by the `model_config` attribute, which enables arbitrary types and ignores extra fields.

## Changes
- The `StrEnum` class is imported from the `enum` module.
- A new `PDFParsingStrategy` enumeration is introduced, offering two parsing strategies: `QuickText` and `ImageToMarkdown`.
- The `ParserConfig class now inherits from `BaseModel`, enabling more flexible configuration.
- The `model_config` attribute is added to the `ParserConfig` class, allowing arbitrary types and ignoring extra fields.
- The `parsing_model` attribute is updated to use `ParsingModel.YoloX_Quantized`.
- The `max_tokens_metadata` attribute is now calculated as `math.floor(num_tokens_per_chunk * 0.1)`.
- A new `pdf_parsing_strategy` attribute is added to the `ParserConfig` class, with a default value of `PDFParsingStrategy.QuickText`.

<!-- end-generated-description -->