### PR TITLE
Add parameters for the new pptx parser

### DIFF
--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -266,6 +266,15 @@ class PDFParsingStrategy(StrEnum):
         return cls.QuickText
 
 
+class PresentationParsingStrategy(StrEnum):
+    Unstructured: str = "Unstructured"
+    ImageToMarkdown: str = "ImageToMarkdown"
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.Unstructured
+
+
 class ParserConfig(BaseModel):
     """
     CompassParser configuration. Important parameters:
@@ -319,6 +328,7 @@ class ParserConfig(BaseModel):
     horizontal_table_crop_margin: int = 100
 
     pdf_parsing_strategy: PDFParsingStrategy = PDFParsingStrategy.QuickText
+    presentation_parsing_strategy: PresentationParsingStrategy = PresentationParsingStrategy.Unstructured
 
 
 ### Document indexing

--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -267,8 +267,8 @@ class PDFParsingStrategy(StrEnum):
 
 
 class PresentationParsingStrategy(StrEnum):
-    Unstructured: str = "Unstructured"
-    ImageToMarkdown: str = "ImageToMarkdown"
+    Unstructured = "Unstructured"
+    ImageToMarkdown = "ImageToMarkdown"
 
     @classmethod
     def _missing_(cls, value):


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new class, `PresentationParsingStrategy`, which extends the `StrEnum` class. This class provides two parsing strategies for presentations: `Unstructured` and `ImageToMarkdown`. The `Unstructured` strategy is set as the default.

The `ParserConfig` class is also updated to include a new parameter, `presentation_parsing_strategy`, which is set to the `Unstructured` strategy by default.

## Changes:
- Added the `PresentationParsingStrategy` class.
- Added the `presentation_parsing_strategy` parameter to the `ParserConfig` class.

<!-- end-generated-description -->