### PR TITLE
Fix bug when adding errors in insert_docs. 

### DIFF
--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -1,4 +1,6 @@
 import logging
+from dataclasses import field
+
 import math
 import uuid
 from enum import Enum, StrEnum
@@ -80,7 +82,7 @@ class CompassDocumentMetadata(ValidatedModel):
 
     doc_id: str = ""
     filename: str = ""
-    meta: List = []
+    meta: List = field(default_factory=list)
     parent_doc_id: str = ""
 
 
@@ -137,12 +139,12 @@ class CompassDocument(ValidatedModel):
 
     filebytes: bytes = b""
     metadata: CompassDocumentMetadata = CompassDocumentMetadata()
-    content: Dict[str, str] = {}
+    content: Dict[str, str] = field(default_factory=dict)
     content_type: Optional[str] = None
-    elements: List[Any] = []
-    chunks: List[CompassDocumentChunk] = []
-    index_fields: List[str] = []
-    errors: List[Dict[CompassSdkStage, str]] = []
+    elements: List[Any] = field(default_factory=list)
+    chunks: List[CompassDocumentChunk] = field(default_factory=list)
+    index_fields: List[str] = field(default_factory=list)
+    errors: List[Dict[CompassSdkStage, str]] = field(default_factory=list)
     ignore_metadata_errors: bool = True
     markdown: Optional[str] = None
 
@@ -364,7 +366,7 @@ class Document(BaseModel):
     parent_doc_id: str
     content: Dict[str, Any]
     chunks: List[Chunk]
-    index_fields: List[str] = []
+    index_fields: List[str] = field(default_factory=list)
 
 
 class ParseableDocument(BaseModel):
@@ -373,10 +375,7 @@ class ParseableDocument(BaseModel):
     """
 
     id: uuid.UUID
-    filename: Annotated[
-        str,
-        StringConstraints(min_length=1),
-    ]  # Ensures the filename is a non-empty string
+    filename: Annotated[str, StringConstraints(min_length=1)]  # Ensures the filename is a non-empty string
     content_type: str
     content_length_bytes: PositiveInt  # File size must be a non-negative integer
     bytes: str  # Base64-encoded file contents

--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -1,8 +1,7 @@
 import logging
-from dataclasses import field
-
 import math
 import uuid
+from dataclasses import field
 from enum import Enum, StrEnum
 from os import getenv
 from typing import Annotated, Any, Dict, List, Optional, Union

--- a/compass_sdk/compass.py
+++ b/compass_sdk/compass.py
@@ -404,8 +404,9 @@ class CompassClient:
         num_chunks = 0
         for num_doc, doc in enumerate(docs, 1):
             if doc.status != CompassDocumentStatus.Success:
-                logger.error(f"[Thread {threading.get_native_id()}] Document #{num_doc} has errors: {doc.errors}")
-                errors.append(doc)
+                logger.error(f"Document {doc.metadata.doc_id} has errors: {doc.errors}")
+                for error in doc.errors:
+                    errors.append({doc.metadata.doc_id: list(error.values())[0]})
             else:
                 num_chunks += len(doc.chunks) if doc.status == CompassDocumentStatus.Success else 0
                 if num_chunks > max_chunks_per_request:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.4.0"
+version = "0.4.1"
 authors = []
 description = "Compass SDK"
 


### PR DESCRIPTION
Also, fix default values in pydantic models

**WHY**
When running `insert_docs`, errors in any document would be appended to a list of `errors` as a new dict `{doc_id: error}`. Hence the format of `errors` is expected to be a `List[Dict[str, str]]`. However, when calling `_get_request_blocks`, accumulated errors in older documents were appended to `errors` like this
```
if doc.status != CompassDocumentStatus.Success:
    logger.error(f"[Thread {threading.get_native_id()}] Document #{num_doc} has errors: {doc.errors}")
    errors.append(doc)
```
This means that `errors` may end up containing either `Dict[str, str]` or `CompassDocument`. Downstream, in North, they were expecting the first, and hence they would do something like `error.keys() for error in errors`, leading to an error like `CompassDocument has no attribute 'keys'`. 

This PR ensures that accumulated doc errors are added in `Dict[str, str]` format. 