### PR TITLE
Removing root from permissions. As root user cannot be created from here

### DIFF
--- a/compass_sdk/types.py
+++ b/compass_sdk/types.py
@@ -48,7 +48,6 @@ class GroupUserDeleteResponse(BaseModel):
 class Permission(Enum):
     READ = "read"
     WRITE = "write"
-    ROOT = "root"
 
 
 class PolicyRequest(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.4.1"
+version = "0.4.2"
 authors = []
 description = "Compass SDK"
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request removes the `ROOT` permission from the `Permission` enum in the `compass_sdk/types.py` file.

- The `ROOT` permission is no longer available in the `Permission` enum.

<!-- end-generated-description -->