### PR TITLE
Configurable heavy parsing strategy

### DIFF
--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -246,6 +246,20 @@ class ParsingStrategy(str, Enum):
         return cls.Fast
 
 
+class HeavyParsingStrategy(StrEnum):
+    """
+    Enum for heavy parsing strategies. Heavy parsing strategies are used to determine when and how to use the "heavier"
+    parsing methods for a document. The "heavier" parsing methods are more computationally expensive and should be used
+    sparingly. The strategies are as follows:
+    - Fallback: Only when the lighter parsing fails.
+    - Complementary: In addition to the lighter parsing. This runs a two-step parsing process, first the lighter parsing
+                        method is used, and then the heavier parsing method updates the results in OS.
+    """
+
+    Fallback = "fallback"
+    Complementary = "complementary"
+
+
 class ParsingModel(str, Enum):
     Marker = "marker"  # Default model, it is actually a combination of models used by the Marker PDF parser
     YoloX_Quantized = "yolox_quantized"  # Only PDF parsing working option from Unstructured
@@ -379,6 +393,7 @@ class ParseableDocument(BaseModel):
     content_length_bytes: PositiveInt  # File size must be a non-negative integer
     bytes: str  # Base64-encoded file contents
     context: Dict[str, Any] = Field(default_factory=dict)
+    heavy_parsing_strategy: HeavyParsingStrategy
 
 
 class PushDocumentsInput(BaseModel):

--- a/compass_sdk/__init__.py
+++ b/compass_sdk/__init__.py
@@ -393,7 +393,7 @@ class ParseableDocument(BaseModel):
     content_length_bytes: PositiveInt  # File size must be a non-negative integer
     bytes: str  # Base64-encoded file contents
     context: Dict[str, Any] = Field(default_factory=dict)
-    heavy_parsing_strategy: HeavyParsingStrategy
+    heavy_parsing_strategy: HeavyParsingStrategy = HeavyParsingStrategy.Fallback
 
 
 class PushDocumentsInput(BaseModel):

--- a/compass_sdk/compass.py
+++ b/compass_sdk/compass.py
@@ -27,7 +27,7 @@ from compass_sdk import (
     PutDocumentsInput,
     SearchFilter,
     SearchInput,
-    logger,
+    logger, HeavyParsingStrategy,
 )
 from compass_sdk.constants import (
     DEFAULT_MAX_ACCEPTED_FILE_SIZE_BYTES,
@@ -257,6 +257,7 @@ class CompassClient:
         content_type: str,
         document_id: uuid.UUID,
         context: Dict[str, Any] = {},
+        heavy_parsing_strategy: HeavyParsingStrategy = HeavyParsingStrategy.Fallback,
         max_retries: int = DEFAULT_MAX_RETRIES,
         sleep_retry_seconds: int = DEFAULT_SLEEP_RETRY_SECONDS,
     ) -> Optional[str | Dict]:
@@ -285,6 +286,7 @@ class CompassClient:
             content_type=content_type,
             content_length_bytes=len(filebytes),
             context=context,
+            heavy_parsing_strategy=heavy_parsing_strategy,
         )
 
         result = self._send_request(

--- a/compass_sdk/compass.py
+++ b/compass_sdk/compass.py
@@ -21,13 +21,14 @@ from compass_sdk import (
     CompassSdkStage,
     Document,
     GroupAuthorizationInput,
+    HeavyParsingStrategy,
     LoggerLevel,
     ParseableDocument,
     PushDocumentsInput,
     PutDocumentsInput,
     SearchFilter,
     SearchInput,
-    logger, HeavyParsingStrategy,
+    logger,
 )
 from compass_sdk.constants import (
     DEFAULT_MAX_ACCEPTED_FILE_SIZE_BYTES,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.4.2"
+version = "0.4.3"
 authors = []
 description = "Compass SDK"
 


### PR DESCRIPTION
Certain document types (i.e., PDF and Slides) have available two parser versions:

Quick, or "lighter" parsing: processes the documents very fast, e.g., with pypdfium2 in the case of PDF, at the cost of semantic elements of the document being lost (e.g., tables and images).
"Heavy parsers", which use MiniCPM to extract the document text in Markdown format.
The default strategy for when to use heavy parsing has been, so far, to trigger it only when quick parsing fails. We call this approach the Fallback heavy parsing strategy.

In this PR, we add an alternative strategy to define when to use heavy parsing:

Complementary: runs heavy parsing after quick parsing, and replaces the document once it is done. This allows the document to be available in the index for retrieval in very short time, while a richer version will be available later.