### PR TITLE
feat: add default timeout

### DIFF
--- a/compass_sdk/compass.py
+++ b/compass_sdk/compass.py
@@ -62,6 +62,19 @@ class CompassMaxErrorRateExceeded(Exception):
         super().__init__(self.message)
 
 
+_DEFAULT_TIMEOUT = 30
+
+
+class SessionWithDefaultTimeout(requests.Session):
+    def __init__(self, timeout: int):
+        self._timeout = timeout
+        super().__init__()
+
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", self._timeout)
+        return super().request(method, url, **kwargs)
+
+
 class CompassClient:
     def __init__(
         self,
@@ -71,6 +84,7 @@ class CompassClient:
         password: Optional[str] = None,
         bearer_token: Optional[str] = None,
         logger_level: LoggerLevel = LoggerLevel.INFO,
+        default_timeout: int = _DEFAULT_TIMEOUT,
     ):
         """
         A compass client to interact with the Compass API
@@ -81,7 +95,7 @@ class CompassClient:
         self.index_url = index_url
         self.username = username or os.getenv("COHERE_COMPASS_USERNAME")
         self.password = password or os.getenv("COHERE_COMPASS_PASSWORD")
-        self.session = requests.Session()
+        self.session = SessionWithDefaultTimeout(default_timeout)
         self.bearer_token = bearer_token
 
         self.function_call = {


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new class, `SessionWithDefaultTimeout`, which extends the `requests.Session` class. This class is designed to handle HTTP requests with a default timeout value.

The `CompassClient` class has been updated to use the new `SessionWithDefaultTimeout` class for its `self.session` attribute, ensuring that all requests made by the client have a default timeout.

## Changes:
- A new class, `SessionWithDefaultTimeout`, is added, which inherits from `requests.Session`.
- The `CompassClient` class now initializes `self.session` with the `SessionWithDefaultTimeout` class, passing the default timeout value as an argument.

<!-- end-generated-description -->