### PR TITLE
[SEA-1683] Fix retry mechanism for 400 errors

### DIFF
--- a/compass_sdk/exceptions.py
+++ b/compass_sdk/exceptions.py
@@ -1,0 +1,29 @@
+class CompassClientError(Exception):
+    """Exception raised for all 4xx client errors in the Compass client."""
+
+    def __init__(self, message="Client error occurred."):
+        self.message = message
+        super().__init__(self.message)
+
+
+class CompassAuthError(CompassClientError):
+    """Exception raised for authentication errors in the Compass client."""
+
+    def __init__(
+        self,
+        message=("CompassAuthError - check your bearer token or username and password."),
+    ):
+        self.message = message
+        super().__init__(self.message)
+
+
+class CompassMaxErrorRateExceeded(Exception):
+    """Exception raised when the error rate exceeds the maximum allowed error rate in
+    the Compass client."""
+
+    def __init__(
+        self,
+        message="The maximum error rate was exceeded. Stopping the insertion process.",
+    ):
+        self.message = message
+        super().__init__(self.message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.5.0"
+version = "0.5.1"
 authors = []
 description = "Compass SDK"
 


### PR DESCRIPTION
We were unnecessarily retrying on all 400 errors except 401. This change should fix the issue.