### PR TITLE
Add asset_type into the DocumentChunkAsset struct

### DIFF
--- a/cohere/compass/models/documents.py
+++ b/cohere/compass/models/documents.py
@@ -22,7 +22,20 @@ class CompassDocumentMetadata(ValidatedModel):
     parent_document_id: str = ""
 
 
+class AssetType(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+    # A page that has been rendered as an image
+    PAGE_IMAGE = "page_image"
+    # A Markdown representation of a page's content
+    PAGE_MARKDOWN = "page_markdown"
+    # A dump of the text extracted from a document
+    DOCUMENT_TEXT = "document_text"
+
+
 class CompassDocumentChunkAsset(BaseModel):
+    asset_type: AssetType
     content_type: str
     asset_data: str
 

--- a/cohere/compass/models/search.py
+++ b/cohere/compass/models/search.py
@@ -1,12 +1,14 @@
 # Python imports
 from enum import Enum
 from typing import Any, Dict, List, Optional
+from cohere.compass.models.documents import AssetType
 
 # 3rd party imports
 from pydantic import BaseModel
 
 
 class AssetInfo(BaseModel):
+    asset_type: AssetType
     content_type: str
     presigned_url: str
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.9.4"
+version = "0.10.0"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
This PR adds the asset_type field to the assets to make it possible to identify what the assets contain.