### PR TITLE
Pyproject version bump 0.9.3 to 0.9.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.9.3"
+version = "0.9.4"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the version of the `compass-sdk` package to `0.9.4`.

- The `version` field in the `[tool.poetry]` section is updated from `0.9.3` to `0.9.4`.

<!-- end-generated-description -->