### PR TITLE
fix: set the default value of DocumentStatus.updated_at to None.

### DIFF
--- a/cohere/compass/models/datasources.py
+++ b/cohere/compass/models/datasources.py
@@ -55,4 +55,4 @@ class DocumentStatus(pydantic.BaseModel):
     state: str
     destinations: typing.List[str]
     created_at: datetime.datetime
-    updated_at: typing.Optional[datetime.datetime]
+    updated_at: typing.Optional[datetime.datetime] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.10.0"
+version = "0.10.1"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the `DocumentStatus` class in the `datasources.py` file and the `version` in the `pyproject.toml` file.

## Changes
- The `updated_at` field in the `DocumentStatus` class is now set to `None` by default.
- The `version` in the `pyproject.toml` file is updated from `0.10.0` to `0.10.1`.

<!-- end-generated-description -->