### PR TITLE
Add type support to update_group_authorization

### DIFF
--- a/cohere/compass/__init__.py
+++ b/cohere/compass/__init__.py
@@ -12,7 +12,7 @@ from cohere.compass.models import (
     ValidatedModel,
 )
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"
 
 
 class ProcessFileParameters(ValidatedModel):

--- a/cohere/compass/__init__.py
+++ b/cohere/compass/__init__.py
@@ -33,14 +33,14 @@ class ProcessFilesParameters(ValidatedModel):
 
 
 class GroupAuthorizationActions(str, Enum):
-    """Enum for use with the edit_group_authorization API to specify the edit type."""
+    """Enum for use with the update_group_authorization API to specify the edit type."""
 
     ADD = "add"
     REMOVE = "remove"
 
 
 class GroupAuthorizationInput(BaseModel):
-    """Model for use with the edit_group_authorization API."""
+    """Model for use with the update_group_authorization API."""
 
     document_ids: list[str]
     authorized_groups: list[str]

--- a/cohere/compass/exceptions.py
+++ b/cohere/compass/exceptions.py
@@ -1,4 +1,10 @@
-class CompassClientError(Exception):
+class CompassError(Exception):
+    """Base class for all exceptions raised by the Compass client."""
+
+    pass
+
+
+class CompassClientError(CompassError):
     """Exception raised for all 4xx client errors in the Compass client."""
 
     def __init__(  # noqa: D107

--- a/cohere/compass/models/documents.py
+++ b/cohere/compass/models/documents.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Annotated, Any, Optional
 
 # 3rd party imports
-from pydantic import BaseModel, Field, PositiveInt, StringConstraints
+from pydantic import BaseModel, ConfigDict, PositiveInt, StringConstraints
 
 # Local imports
 from cohere.compass.models import ValidatedModel
@@ -195,6 +195,19 @@ class Document(BaseModel):
     authorized_groups: Optional[list[str]] = None
 
 
+class DocumentAttributes(BaseModel):
+    """Model class for document attributes."""
+
+    model_config = ConfigDict(extra="allow")
+
+    # Had to add this to please the linter, because BaseModel only defines __setattr__
+    # if TYPE_CHECKING is not set, i.e. at runtime, resulting in the type checking pass
+    # done by the linter failing to find the __setattr__ method. See:
+    # https://github.com/pydantic/pydantic/blob/main/pydantic/main.py#L878-L920
+    def __setattr__(self, name: str, value: Any):  # noqa: D105
+        return super().__setattr__(name, value)
+
+
 class ParseableDocument(BaseModel):
     """A document to be sent to Compass for parsing."""
 
@@ -205,7 +218,7 @@ class ParseableDocument(BaseModel):
     content_type: str
     content_length_bytes: PositiveInt  # File size must be a non-negative integer
     content_encoded_bytes: str  # Base64-encoded file contents
-    attributes: dict[str, Any] = Field(default_factory=dict)
+    attributes: DocumentAttributes
 
 
 class UploadDocumentsInput(BaseModel):

--- a/cohere/compass/models/documents.py
+++ b/cohere/compass/models/documents.py
@@ -233,3 +233,20 @@ class PutDocumentsInput(BaseModel):
     documents: list[Document]
     authorized_groups: Optional[list[str]] = None
     merge_groups_on_conflict: bool = False
+
+
+class PutDocumentResult(BaseModel):
+    """
+    A model for the response of put_document.
+
+    This model is also used by the put_documents and edit_group_authorization APIs.
+    """
+
+    document_id: str
+    error: Optional[str]
+
+
+class PutDocumentsResponse(BaseModel):
+    """A model for the response of put_documents and edit_group_authorization APIs."""
+
+    results: list[PutDocumentResult]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.10.2"
+version = "0.11.0"
 authors = []
 description = "Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -66,7 +66,7 @@ def test_get_documents_is_valid(requests_mock: Mocker):
 
 def test_refresh_is_valid(requests_mock: Mocker):
     compass = CompassClient(index_url="http://test.com")
-    compass.refresh(index_name="test_index")
+    compass.refresh_index(index_name="test_index")
     assert requests_mock.request_history[0].method == "POST"
     assert (
         requests_mock.request_history[0].url

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -2,6 +2,7 @@ from requests_mock import Mocker
 
 from cohere.compass.clients import CompassClient
 from cohere.compass.models import CompassDocument
+from cohere.compass.models.documents import DocumentAttributes
 
 
 def test_delete_url_formatted_with_doc_and_index(requests_mock: Mocker):
@@ -74,9 +75,13 @@ def test_refresh_is_valid(requests_mock: Mocker):
 
 
 def test_add_attributes_is_valid(requests_mock: Mocker):
+    attrs = DocumentAttributes()
+    attrs.fake = "context"
     compass = CompassClient(index_url="http://test.com")
     compass.add_attributes(
-        index_name="test_index", document_id="test_id", context={"fake": "context"}
+        index_name="test_index",
+        document_id="test_id",
+        attributes=attrs,
     )
     assert requests_mock.request_history[0].method == "POST"
     assert (


### PR DESCRIPTION
The main contribution of this PR is:

- The API used to return the RetryResult object. Now it returns a strong type.
- It used to be called `edit_group_authorization`. I renamed to `update_group_authorization` to match the API name.

While at this, I also changed the `_send_request` API to only accept objects of type BaseModel.  This is to reduce its complexity, and also the unify the way we are sending and receiving objects.