### PR TITLE
Reduce num_worker to 1

### DIFF
--- a/cohere/compass/clients/parser.py
+++ b/cohere/compass/clients/parser.py
@@ -53,7 +53,7 @@ class CompassParserClient:
         metadata_config: MetadataConfig = MetadataConfig(),
         username: Optional[str] = None,
         password: Optional[str] = None,
-        num_workers: int = 4,
+        num_workers: int = 1,
     ):
         """
         Initialize the CompassParserClient.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.11.0"
+version = "0.11.1"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Setting a lower default value as we have only one cpu unit on the parser
User can increase it depending on the number of cpu cores or pod's