### PR TITLE
Remove use of RetryResult for add_attributes

### DIFF
--- a/cohere/compass/__init__.py
+++ b/cohere/compass/__init__.py
@@ -12,7 +12,7 @@ from cohere.compass.models import (
     ValidatedModel,
 )
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 
 class ProcessFileParameters(ValidatedModel):

--- a/cohere/compass/clients/compass.py
+++ b/cohere/compass/clients/compass.py
@@ -64,13 +64,15 @@ from cohere.compass.models.documents import DocumentAttributes, PutDocumentsResp
 
 
 @dataclass
-class RetryResult:
+class _RetryResult:
     """
     A class to represent the result of a retryable operation.
 
     The class contains the following fields:
     - result: The result of the operation if successful, otherwise None.
     - error (Optional[str]): The error message if the operation failed, otherwise None.
+
+    Notice that this is an internal class and should not be exposed to clients.
     """
 
     result: Optional[dict[str, Any]] = None
@@ -247,7 +249,7 @@ class CompassClient:
         attributes: DocumentAttributes,
         max_retries: int = DEFAULT_MAX_RETRIES,
         sleep_retry_seconds: int = DEFAULT_SLEEP_RETRY_SECONDS,
-    ) -> Optional[RetryResult]:
+    ) -> Optional[str]:
         """
         Update the content field of an existing document with additional context.
 
@@ -257,8 +259,10 @@ class CompassClient:
         :param max_retries: the maximum number of times to retry a doc insertion
         :param sleep_retry_seconds: number of seconds to go to sleep before retrying a
             doc insertion
+
+        :returns: an error message if the request failed, otherwise None
         """
-        return self._send_request(
+        result = self._send_request(
             api_name="add_attributes",
             document_id=document_id,
             data=attributes,
@@ -266,6 +270,9 @@ class CompassClient:
             sleep_retry_seconds=sleep_retry_seconds,
             index_name=index_name,
         )
+        if result.error:
+            return result.error
+        return None
 
     def insert_doc(
         self,
@@ -772,7 +779,7 @@ class CompassClient:
         sleep_retry_seconds: int,
         data: Optional[BaseModel] = None,
         **url_params: str,
-    ) -> RetryResult:
+    ) -> _RetryResult:
         """
         Send a request to the Compass API.
 
@@ -815,7 +822,7 @@ class CompassClient:
                 if response.ok:
                     error = None
                     result = response.json() if response.text else None
-                    return RetryResult(result=result, error=None)
+                    return _RetryResult(result=result, error=None)
                 else:
                     response.raise_for_status()
 
@@ -855,9 +862,9 @@ class CompassClient:
             if res:
                 return res
             else:
-                return RetryResult(result=None, error=error)
+                return _RetryResult(result=None, error=error)
         except RetryError:
             logger.error(
                 f"Failed to send request after {max_retries} attempts. Aborting."
             )
-            return RetryResult(result=None, error=error)
+            return _RetryResult(result=None, error=error)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.11.1"
+version = "0.12.0"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Like the rest of the APIs, I changed the `add_attributes` method to return the result (which in this case is None) in case of success or the error string in case of failures.

I also renamed RetryResult to `_RetryResult` to clearly indicate that this is an internal class that shouldn't be exposed externally.