### PR TITLE
Raise exception in case of errors in search APIs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,5 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    "python.defaultInterpreterPath": "./.venv/bin/python",
 }

--- a/cohere/compass/clients/compass.py
+++ b/cohere/compass/clients/compass.py
@@ -727,6 +727,9 @@ class CompassClient:
             filters=filters,
         )
 
+        if result.error:
+            raise CompassError(result.error)
+
         return SearchDocumentsResponse.model_validate(result.result)
 
     def search_chunks(
@@ -754,6 +757,9 @@ class CompassClient:
             top_k=top_k,
             filters=filters,
         )
+
+        if result.error:
+            raise CompassError(result.error)
 
         return SearchChunksResponse.model_validate(result.result)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.14.1"
+version = "0.14.2"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
The `search_chunks` and `search_documents` APIs are not handling errors in responses, resulting in the error response from the APIs being parsed as a Pydantic model, which shows a confusing error to the clients. This should fix it.