### PR TITLE
feat: Add support for bearer tokens to CompassParserClient

### DIFF
--- a/cohere/compass/clients/parser.py
+++ b/cohere/compass/clients/parser.py
@@ -65,6 +65,7 @@ class CompassParserClient:
         metadata_config: MetadataConfig = MetadataConfig(),
         username: Optional[str] = None,
         password: Optional[str] = None,
+        bearer_token: Optional[str] = None,
         num_workers: int = 1,
     ):
         """
@@ -83,6 +84,9 @@ class CompassParserClient:
         :param metadata_config: the metadata configuration to use when processing files
             if no metadata configuration is specified in the method calls (process_file
             or process_files)
+        :param username (optional): The username for authentication.
+        :param password (optional): The password for authentication.
+        :param bearer_token (optional): The bearer token for authentication.
         """
         self.parser_url = (
             parser_url if not parser_url.endswith("/") else parser_url[:-1]
@@ -90,6 +94,7 @@ class CompassParserClient:
         self.parser_config = parser_config
         self.username = username or os.getenv("COHERE_COMPASS_USERNAME")
         self.password = password or os.getenv("COHERE_COMPASS_PASSWORD")
+        self.bearer_token = bearer_token
         self.session = requests.Session()
         self.thread_pool = ThreadPoolExecutor(num_workers)
         self.num_workers = num_workers
@@ -266,14 +271,21 @@ class CompassParserClient:
             doc_id=file_id,
             content_type=content_type,
         )
-        auth = (
-            (self.username, self.password) if self.username and self.password else None
-        )
+
+        headers = None
+        auth = None
+        if self.username and self.password:
+            auth = (self.username, self.password)
+        if self.bearer_token:
+            headers = {"Authorization": f"Bearer {self.bearer_token}"}
+            auth = None
+
         res = self.session.post(
             url=f"{self.parser_url}/v1/process_file",
             data={"data": json.dumps(params.model_dump())},
             files={"file": (filename, doc.filebytes)},
             auth=auth,
+            headers=headers,
         )
 
         if res.ok:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.15.1"
+version = "0.15.2"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Allows supporting configurations where Parser authenticates using a Bearer token and not just user/password authentication.