### PR TITLE
chore(send_request): change retry logs to warn

### DIFF
--- a/cohere/compass/clients/compass.py
+++ b/cohere/compass/clients/compass.py
@@ -908,7 +908,7 @@ class CompassClient:
                     raise CompassClientError(message=error, code=e.response.status_code)
                 else:
                     error = str(e) + " " + e.response.text
-                    logger.error(
+                    logger.warning(
                         f"Failed to send request to {api_name} {target_path}: "
                         f"{type(e)} {error}. Going to sleep for "
                         f"{sleep_retry_seconds} seconds and retrying."
@@ -920,7 +920,7 @@ class CompassClient:
 
             except Exception as e:
                 error = str(e)
-                logger.error(
+                logger.warning(
                     f"Failed to send request to {api_name} {target_path}: {type(e)} "
                     f"{error}. Sleeping for {sleep_retry_seconds} before retrying..."
                 )


### PR DESCRIPTION
# Overview

Retries are natural to happen and shouldn't log an error message but a warning, and only log an error if all retries failed, i.e. we couldn't make the request. This way we avoid unnecessary error logs if an API is temporarily unreliable.

# Context

In [SEA-1941](https://linear.app/cohereai/issue/SEA-1941/huge-volume-of-compass-related-logs) one of the complaints that North raised was related to retry logs which, along along with another issue, resulting in a huge volume of logs and frequent log rotation. The other issue (dumping asset base64 content in logs) was the major issue. However, to help them (and clients in general) in focusing on the important logs, we are making the retry logs warning, unless all retries fail in which cause we emit an error log. This way the logs dashboard for errors don't show transient error that didn't actually cause any issue.
