### PR TITLE
fix(parsing): [CMPS-28] Surface parsing errors

### DIFF
--- a/examples/compass_sdk_examples/create_index.py
+++ b/examples/compass_sdk_examples/create_index.py
@@ -1,5 +1,7 @@
 import argparse
 
+from cohere.compass.models import CompassDocument
+
 from compass_sdk_examples.utils import get_compass_api, get_compass_parser
 
 
@@ -44,7 +46,14 @@ def main():
 
     print(f"Inserting documents from {folder_path} into index '{index_name}'...")
     parser = get_compass_parser()
-    docs = parser.process_folder(folder_path=folder_path)
+    docs: list[CompassDocument] = []
+    response = parser.process_folder(folder_path=folder_path)
+    for d in response:
+        if isinstance(d, tuple):
+            filename, ex = d
+            print(f"Failed to parse {filename}: {ex}")
+        else:
+            docs.append(d)
     client.insert_docs(index_name="cohere-papers", docs=iter(docs))
     print("Documents inserted into index 'cohere-papers'.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "0.18.0"
+version = "0.19.0"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Update the `process_file` API to raise an exception in case there is an issue with parsing. The `process_files` API, which internally makes parallel calls to `process_file`, was then updated to capture exceptions raised by `process_file` and return them to the user so the user can track failed files.

This change also impacts the `process_folder` since it internally calls the `process_files` API.

This change is not backward compatible, and hence the minor version was bumped.
