### PR TITLE
feat: Add a new example for parsing documents

### DIFF
--- a/cohere-compass-sdk.code-workspace
+++ b/cohere-compass-sdk.code-workspace
@@ -14,6 +14,18 @@
 		}
 	],
 	"settings": {
-		"window.title": "📦 Compass SDK 📦"
+		"files.exclude": {
+			"**/.git": true,
+			"**/.pytest_cache": true,
+			"**/.ruff_cache": true,
+			"**/__pycache__": true,
+		},
+		"search.exclude": {
+			"**/.git": true,
+			"**/.pytest_cache": true,
+			"**/.ruff_cache": true,
+			"**/__pycache__": true,
+		},
+		"window.title": "📦 Compass SDK 📦",
 	}
 }

--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -11,10 +11,31 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Debug scroll_all_chunks",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/compass_sdk_examples/scroll_all_chunks.py",
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Debug list_indexes",
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/compass_sdk_examples/list_indexes.py",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Debug get_document_asset",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/compass_sdk_examples/get_document_asset.py",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Debug parse_document",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/compass_sdk_examples/parse_document.py",
             "console": "integratedTerminal"
         },
         {

--- a/examples/compass_sdk_examples/parse_document.py
+++ b/examples/compass_sdk_examples/parse_document.py
@@ -1,0 +1,44 @@
+import argparse
+import json
+
+from cohere_compass.models import ParserConfig, PDFParsingStrategy
+
+from compass_sdk_examples.utils import get_compass_parser
+
+
+def parse_args():
+    """
+    Parse the user arguments using argparse.
+    """
+    # Set up argument parsing
+    parser = argparse.ArgumentParser(
+        description="This script parses a file using Compass Parser."
+    )
+
+    # Arguments
+    parser.add_argument(
+        "--file",
+        type=str,
+        help="Specify the name of the file to parse.",
+        required=True,
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    parser = get_compass_parser()
+    docs = parser.process_file(
+        filename=args.file,
+        parser_config=ParserConfig(
+            pdf_parsing_strategy=PDFParsingStrategy.ImageToMarkdown
+        ),
+    )
+    for doc in docs:
+        print(json.dumps(doc.content, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/compass_sdk_examples/utils.py
+++ b/examples/compass_sdk_examples/utils.py
@@ -2,6 +2,7 @@ import os
 
 import dotenv
 from cohere_compass.clients import CompassClient, CompassParserClient
+from cohere_compass.models import ParserConfig
 
 dotenv.load_dotenv()  # type: ignore
 
@@ -27,13 +28,15 @@ def get_compass_api():
     return CompassClient(index_url=api_url, bearer_token=bearer_token)
 
 
-def get_compass_parser():
+def get_compass_parser(parser_config: ParserConfig = ParserConfig()):
     """
     Create and return an instance of CompassParserClient.
 
     Args:
         parser_base_url (str): The base URL of the parser service.
         bearer_token (str, optional): The bearer token for auth. Defaults to None.
+        parser_config (ParserConfig, optional): The parser configuration. Defaults to
+            `ParserConfig()`.
 
     Returns:
         CompassParserClient: An instance of CompassParserClient.
@@ -45,4 +48,8 @@ def get_compass_parser():
             "COMPASS_PARSER_URL environment variable must be set in your .env file."
         )
     bearer_token = os.getenv("COMPASS_PARSER_BEARER_TOKEN")
-    return CompassParserClient(parser_url=parser_url, bearer_token=bearer_token)
+    return CompassParserClient(
+        parser_url=parser_url,
+        bearer_token=bearer_token,
+        parser_config=parser_config,
+    )

--- a/examples/poetry.lock
+++ b/examples/poetry.lock
@@ -141,7 +141,7 @@ files = [
 
 [[package]]
 name = "compass-sdk"
-version = "0.16.0"
+version = "0.21.0"
 description = "Compass SDK"
 optional = false
 python-versions = ">=3.9,<4.0"


### PR DESCRIPTION
The example calls the `process_file` of the parser SDK to parse a document.