### PR TITLE
chore: updating the README.md to show V2 RBAC usage instead of V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,34 +152,46 @@ print(f"Results preview: \n {result.hits} ... \n \n ")
 ### RBAC
 
 ```python
-from cohere_compass.clients.rbac import CompassRootClient
-from cohere_compass.clients.rbac import UserCreateRequest
-from cohere_compass.models.rbac import GroupCreateRequest, RoleCreateRequest, RoleMappingRequest, Permission, PolicyRequest
-from cohere_compass.clients.rbac import UserCreateResponse
+from cohere_compass.clients.access_control import CompassRootClient
+from cohere_compass.models.access_control import Group, Permission, Policy, Role, User
 from requests.exceptions import HTTPError
 
 ROOT_BEARER_TOKEN = "<ROOT_BEARER_TOKEN>"
 API_URL = "<API_URL>"
 compass_root = CompassRootClient(API_URL, ROOT_BEARER_TOKEN)
 
-user_names = ["<USER_NAME>"]
-group_name = "<GROUP_NAME>"
-role_name = "<ROLE_NAME>"
+user = User(user_name="<USER_NAME>")
+group = Group(group_name="<GROUP_NAME>")
+role = Role(role_name="<ROLE_NAME>")
 indexes = ["<ALLOWED_INDEX or REGEX>"]
 permission = Permission.WRITE # or Permission.READ
 
 try:
-    # Create users
-    users_create_request = [UserCreateRequest(name=user_name) for user_name in user_names]
-    users: list[UserCreateResponse] = compass_root.create_users(users=users_create_request)
+    # Create Users
+    users = client.create_users([user])
 
-    # Add users to group
-    compass_root.create_groups(groups=[GroupCreateRequest(name=group_name, user_names=user_names)])
+    # Create Groups
+    groups = client.create_groups([group])
 
-    # Create a role
-    compass_root.create_roles(roles=[RoleCreateRequest(name=role_name, policies=[PolicyRequest(indexes=indexes, permission=permission)])])
-    # Map role to groups
-    compass_root.create_role_mappings(role_mappings=[RoleMappingRequest(role_name=role_name, group_name=group_name)])
+    # Add Users to a Group
+    memberships = client.add_members_to_group(group.group_name, [user.user_name])
+
+    # Add Policies and Create a Role
+    role.policies = [
+        Policy(permission=Permission.READ, indexes=indexes),
+    ]
+    roles = client.create_roles([role])
+
+    # Update Role Policies
+    role.policies = [
+        Policy(permission=Permission.READ, indexes=indexes),
+        Policy(permission=Permission.WRITE, indexes=indexes),
+    ]
+    role = client.update_role(role)
+
+    # Assign Roles to a Group
+    role_assignments = client.add_roles_to_group(group.group_name, [role.role_name])
+
     # Token for the user to access the indexes
     USER_TO_TOKENS = {user.name: user.token for user in users}
 except HTTPError as e:
@@ -187,26 +199,103 @@ except HTTPError as e:
         print("A entity already exists", e.response.json())
 ```
 
-### Deleting RBAC
+### Reading RBAC Information
 
 ```python
-from cohere_compass.clients.rbac import CompassRootClient
+from cohere_compass.clients.access_control import CompassRootClient
+from cohere_compass.models.access_control import Group, Role, User, PageDirection
+from requests.exceptions import HTTPError
 
 ROOT_BEARER_TOKEN = "<ROOT_BEARER_TOKEN>"
 API_URL = "<API_URL>"
 compass_root = CompassRootClient(API_URL, ROOT_BEARER_TOKEN)
 
-user_names = ["<USER_NAME>"]
-group_names = ["<GROUP_NAME>"]
-role_names = ["<ROLE_NAME>"]
+user = User(user_name="<USER_NAME>")
+group = Group(group_name="<GROUP_NAME>")
+role = Role(role_name="<ROLE_NAME>")
 
-compass_root.delete_roles(role_ids=role_names)
-compass_root.delete_groups(group_names=group_names)
-compass_root.delete_users(user_names=user_names)
+# List all Users in the RBAC system
+# First page
+user_page = client.get_users_page()
+# Subsequent pages
+user_page = client.get_users_page(page_info=user_page.page_info, direction=PageDirection.NEXT)
 
-role_mapping_role_name = "<ROLE_NAME>"
-role_mapping_group_name = "<GROUP_NAME>"
-compass_root.delete_role_mappings(role_name=role_mapping_role_name, group_name=role_mapping_group_name)
+# List all Groups in the RBAC system
+# First page
+group_page = client.get_groups_page()
+# Subsequent pages
+group_page = client.get_groups_page(page_info=group_page.page_info, direction=PageDirection.NEXT)
+
+# List all Roles in the RBAC system
+# First page
+role_page = client.get_roles_page()
+# Subsequent pages
+role_page = client.get_roles_page(page_info=role_page.page_info, direction=PageDirection.NEXT)
+
+# Get the Group Details (all data + first page each of Users who are Members and Roles Assigned)
+detailed_group = client.get_detailed_group(group.group_name)
+
+# Get pages of Group's User Memberships
+# First page
+memberships = client.get_group_members_page(group.group_name)
+# Subsequent pages (can use the users_page_info from details)
+memberships = client.get_group_members_page(group.group_name, page_info=memberships.page_info, direction=PageDirection.NEXT)
+
+# Get pages of Group's Roles Assignments
+# First page
+role_assignments = client.get_group_roles_page(group.group_name)
+# Subsequent pages (can use the role_page_info from details)
+role_assignments = client.get_group_roles_page(group.group_name, page_info=role_assignments.page_info, direction=PageDirection.NEXT)
+
+# Get the User Details (all data + first page of Groups that the User is a Member of)
+detailed_user = client.get_detailed_user(user.user_name)
+
+# Get pages of User's Group Memberships
+# First page
+group_memberships = client.get_user_groups_page(user.user_name)
+# Subsequent pages (can use the group_page_info from details)
+group_memberships = client.get_user_groups_page(user.user_name, page_info=group_memberships.page_info, direction=PageDirection.NEXT)
+
+# Get the Roles Details (all data + first page of Groups the Role is Assigned to)
+detailed_role = client.get_detailed_role(role.role_name)
+
+# Get pages of Role's Group Assignments
+group_assignments = client.get_role_groups_page(role.role_name)
+# Subsequent pages (can use the group_page_info from details)
+group_assignments = client.get_role_groups_page(role.role_name, page_info=group_assignments.page_info, direction=PageDirection.NEXT)
+
+# Filtering any Page type query, exemplified on Users Page, but works with all.
+user_page = client.get_users_page(filter="<SOME_NAME_OR_NAME_PARTIAL>")
+```
+
+### Deleting RBAC
+
+```python
+from cohere_compass.clients.access_control import CompassRootClient
+from cohere_compass.models.access_control import Group, Role, User
+
+ROOT_BEARER_TOKEN = "<ROOT_BEARER_TOKEN>"
+API_URL = "<API_URL>"
+compass_root = CompassRootClient(API_URL, ROOT_BEARER_TOKEN)
+
+user = User(user_name="<USER_NAME>")
+group = Group(group_name="<GROUP_NAME>")
+role = Role(role_name="<ROLE_NAME>")
+
+# removing Roles from a Group
+removed_roles = client.remove_roles_from_group(group.group_name, [role.role_name])
+
+# removing Members from a Group
+removed_members = client.remove_members_from_group(group.group_name, [user.user_name])
+
+# deleting Roles
+deleted_roles = client.delete_roles([role.role_name])
+
+# deleting Groups
+deleted_groups = client.delete_groups([group.group_name])
+
+# deleting Users
+deleted_users = client.delete_users([user.user_name])
 ```
 
 ## Local Development


### PR DESCRIPTION
<!-- begin-generated-description -->

## Changes
- RBAC code has been updated to use the new access_control module instead of the old rbac module.
- User, Group, and Role objects are now created using the new access_control models.
- The code for creating users, groups, and roles has been updated to use the new client methods.
- The code for adding users to groups, creating roles, and mapping roles to groups has been updated to use the new client methods.
- New code has been added for reading RBAC information, including listing users, groups, and roles, and getting detailed information about groups, users, and roles.
- The code for deleting RBAC entities has been updated to use the new client methods.

## Highlights
- Updated imports to use the new access_control module.
- Replaced UserCreateRequest, GroupCreateRequest, RoleCreateRequest, and RoleMappingRequest with the new User, Group, and Role models.
- Updated the code for creating users, groups, and roles to use the new client methods: create_users, create_groups, and create_roles.
- Added new code for adding users to groups, creating roles, and mapping roles to groups using the new client methods: add_members_to_group, add_roles_to_group, and update_role.
- Added new code for reading RBAC information, including listing users, groups, and roles, and getting detailed information about groups, users, and roles using the new client methods: get_users_page, get_groups_page, get_roles_page, get_detailed_group, get_detailed_user, and get_detailed_role.
- Updated the code for deleting RBAC entities to use the new client methods: remove_roles_from_group, remove_members_from_group, delete_roles, delete_groups, and delete_users.

<!-- end-generated-description -->