### PR TITLE
fix: Remove required `/api` in url as not every deployment would have it

### DIFF
--- a/cohere_compass/clients/access_control.py
+++ b/cohere_compass/clients/access_control.py
@@ -26,14 +26,22 @@ from cohere_compass.models.access_control import (
 class CompassRootClient:
     """Client for interacting with Compass RBAC API V2 as a root user."""
 
-    def __init__(self, compass_url: str, root_user_token: str):
+    def __init__(
+        self, compass_url: str, root_user_token: str, include_api_in_url: bool = True
+    ):
         """
         Initialize a new CompassRootClient.
 
         :param compass_url: URL of the Compass instance.
         :param root_user_token: Root user token for Compass instance.
+        :param include_api_in_url: Whether to include '/api' in the base URL.
+               Defaults to True.
         """
-        self.base_url = compass_url + "/api/security/admin/rbac"
+        self.base_url = (
+            compass_url
+            + ("/api" if include_api_in_url else "")
+            + "/security/admin/rbac"
+        )
         self.headers = {
             "Authorization": f"Bearer {root_user_token}",
             "Content-Type": "application/json",

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -98,6 +98,7 @@ class CompassClient:
         http_session: Optional[requests.Session] = None,
         default_max_retries: int = DEFAULT_MAX_RETRIES,
         default_sleep_retry_seconds: int = DEFAULT_SLEEP_RETRY_SECONDS,
+        include_api_in_url: bool = True,
     ):
         """
         Initialize the Compass client.
@@ -105,6 +106,8 @@ class CompassClient:
         :param index_url: The base URL for the index API.
         :param bearer_token (optional): The bearer token for authentication.
         :param http_session (optional): An optional HTTP session to use for requests.
+        :param include_api_in_url: Whether to include '/api' in the base URL.
+               Defaults to True.
         """
         self.index_url = index_url
         self.session = http_session or requests.Session()
@@ -142,29 +145,30 @@ class CompassClient:
             "sync_datasource": self.session.post,
             "list_datasources_objects_states": self.session.get,
         }
+        base_api = "/api" if include_api_in_url else ""
         self.api_endpoint = {
-            "create_index": "/api/v1/indexes/{index_name}",
-            "list_indexes": "/api/v1/indexes",
-            "delete_index": "/api/v1/indexes/{index_name}",
-            "delete_document": "/api/v1/indexes/{index_name}/documents/{document_id}",
-            "get_document": "/api/v1/indexes/{index_name}/documents/{document_id}",
-            "put_documents": "/api/v1/indexes/{index_name}/documents",
-            "search_documents": "/api/v1/indexes/{index_name}/documents/_search",
-            "search_chunks": "/api/v1/indexes/{index_name}/documents/_search_chunks",
-            "get_document_asset": "/api/v1/indexes/{index_name}/documents/{document_id}/assets/{asset_id}",  # noqa: E501
-            "add_attributes": "/api/v1/indexes/{index_name}/documents/{document_id}/_add_attributes",  # noqa: E501
-            "refresh": "/api/v1/indexes/{index_name}/_refresh",
-            "upload_documents": "/api/v1/indexes/{index_name}/documents/_upload",
-            "update_group_authorization": "/api/v1/indexes/{index_name}/group_authorization",  # noqa: E501
-            "direct_search": "/api/v1/indexes/{index_name}/_direct_search",
-            "direct_search_scroll": "/api/v1/indexes/_direct_search/scroll",
+            "create_index": f"{base_api}/v1/indexes/{{index_name}}",
+            "list_indexes": f"{base_api}/v1/indexes",
+            "delete_index": f"{base_api}/v1/indexes/{{index_name}}",
+            "delete_document": f"{base_api}/v1/indexes/{{index_name}}/documents/{{document_id}}",  # noqa: E501
+            "get_document": f"{base_api}/v1/indexes/{{index_name}}/documents/{{document_id}}",  # noqa: E501
+            "put_documents": f"{base_api}/v1/indexes/{{index_name}}/documents",
+            "search_documents": f"{base_api}/v1/indexes/{{index_name}}/documents/_search",  # noqa: E501
+            "search_chunks": f"{base_api}/v1/indexes/{{index_name}}/documents/_search_chunks",  # noqa: E501
+            "get_document_asset": f"{base_api}/v1/indexes/{{index_name}}/documents/{{document_id}}/assets/{{asset_id}}",  # noqa: E501
+            "add_attributes": f"{base_api}/v1/indexes/{{index_name}}/documents/{{document_id}}/_add_attributes",  # noqa: E501
+            "refresh": f"{base_api}/v1/indexes/{{index_name}}/_refresh",
+            "upload_documents": f"{base_api}/v1/indexes/{{index_name}}/documents/_upload",  # noqa: E501
+            "update_group_authorization": f"{base_api}/v1/indexes/{{index_name}}/group_authorization",  # noqa: E501
+            "direct_search": f"{base_api}/v1/indexes/{{index_name}}/_direct_search",
+            "direct_search_scroll": f"{base_api}/v1/indexes/_direct_search/scroll",
             # Data Sources APIs
-            "create_datasource": "/api/v1/datasources",
-            "list_datasources": "/api/v1/datasources",
-            "delete_datasources": "/api/v1/datasources/{datasource_id}",
-            "get_datasource": "/api/v1/datasources/{datasource_id}",
-            "sync_datasource": "/api/v1/datasources/{datasource_id}/_sync",
-            "list_datasources_objects_states": "/api/v1/datasources/{datasource_id}/documents?skip={skip}&limit={limit}",  # noqa: E501
+            "create_datasource": f"{base_api}/v1/datasources",
+            "list_datasources": f"{base_api}/v1/datasources",
+            "delete_datasources": f"{base_api}/v1/datasources/{{datasource_id}}",
+            "get_datasource": f"{base_api}/v1/datasources/{{datasource_id}}",
+            "sync_datasource": f"{base_api}/v1/datasources/{{datasource_id}}/_sync",
+            "list_datasources_objects_states": f"{base_api}/v1/datasources/{{datasource_id}}/documents?skip={{skip}}&limit={{limit}}",  # noqa: E501
         }
 
     def create_index(

--- a/cohere_compass/clients/rbac.py
+++ b/cohere_compass/clients/rbac.py
@@ -35,14 +35,22 @@ class CompassRootClient:
     Prefer the CompassRootClient in access_control.py for new development.
     """
 
-    def __init__(self, compass_url: str, root_user_token: str):
+    def __init__(
+        self, compass_url: str, root_user_token: str, include_api_in_url: bool = True
+    ):
         """
         Initialize a new CompassRootClient.
 
         :param compass_url: URL of the Compass instance.
         :param root_user_token: Root user token for Compass instance.
+        :param include_api_in_url: Whether to include '/api' in the base URL.
+               Defaults to True.
         """
-        self.base_url = compass_url + "/api/security/admin/rbac"
+        self.base_url = (
+            compass_url
+            + ("/api" if include_api_in_url else "")
+            + "/security/admin/rbac"
+        )
         self.headers = {
             "Authorization": f"Bearer {root_user_token}",
             "Content-Type": "application/json",

--- a/examples/poetry.lock
+++ b/examples/poetry.lock
@@ -141,7 +141,7 @@ files = [
 
 [[package]]
 name = "compass-sdk"
-version = "1.0.0"
+version = "1.0.1"
 description = "Compass SDK"
 optional = false
 python-versions = ">=3.9,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "1.0.0"
+version = "1.0.1"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR introduces a new parameter, `include_api_in_url`, to the `CompassRootClient` and `CompassClient` classes. This parameter allows users to specify whether the `/api` segment should be included in the base URL. The default value is set to `True` to maintain backward compatibility.

## Changes
- **Added `include_api_in_url` Parameter**: A new optional parameter, `include_api_in_url`, has been added to the `__init__` methods of both `CompassRootClient` and `CompassClient`. This parameter controls whether the `/api` segment is included in the base URL.
- **Updated Base URL Construction**: The construction of the `base_url` has been updated to conditionally include `/api` based on the value of `include_api_in_url`.
- **Updated API Endpoints**: In `CompassClient`, the API endpoints have been updated to use an `f-string` with the `base_api` variable, which is determined by the `include_api_in_url` parameter. This ensures that the `/api` segment is only included when necessary.

<!-- end-generated-description -->