### PR TITLE
feat: updates to SDK to support multiple models mode for Compass

### DIFF
--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -246,9 +246,15 @@ class IndexConfig(BaseModel):
         by cohere.
     :param analyzer: Analyzer is a parameter set for multilinguality. If None
         it will use the default from compass.
+    :param dense_model: the dense model to use for the index. Leave unset unless advised
+        by cohere.
+    :param sparse_model: the sparse model to use for the index. Leave unset unless
+        advised by cohere.
     """
 
     number_of_shards: Optional[int] = None
     number_of_replicas: Optional[int] = None
     knn_index_engine: Optional[str] = None
     analyzer: Optional[str] = None
+    dense_model: Optional[str] = None
+    sparse_model: Optional[str] = None

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -84,6 +84,7 @@ class SearchInput(BaseModel):
     query: str
     top_k: int
     filters: Optional[list[SearchFilter]] = None
+    rerank_model: Optional[str] = None
 
 
 class DirectSearchInput(BaseModel):

--- a/examples/fern_documentation/python/core/get_models.py
+++ b/examples/fern_documentation/python/core/get_models.py
@@ -1,0 +1,14 @@
+from cohere_compass.clients.compass import CompassClient
+from cohere_compass.exceptions import CompassError
+
+COMPASS_API_URL = ...
+BEARER_TOKEN = ...
+
+client = CompassClient(index_url=COMPASS_API_URL, bearer_token=BEARER_TOKEN)
+try:
+    models = client.get_models()
+    print("Available models:")
+    for role, versions in models.items():
+        print(f"Role: {role}, Versions: {versions}")
+except CompassError as e:
+    print(f"Error fetching models: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compass-sdk"
-version = "1.3.1"
+version = "1.3.2"
 authors = []
 description = "Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Updates IndexConfig for `create_index` to add the `dense_model` and `sparse_model` params
Updates the SearchConfig used for `search_docs` and `search_chunks` to add `rerank_model` param
Adds the new `get_models` method to retrieve the list of configured models for a Compass server.
Provide a code sample for `get_models`