### PR TITLE
feat: Add enable_assets_returned_as_base64 to ParserConfig

### DIFF
--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -182,6 +182,8 @@ class ParserConfig(BaseModel):
         PresentationParsingStrategy.Unstructured
     )
 
+    enable_assets_returned_as_base64: bool = True
+
 
 class MetadataStrategy(str, Enum):
     """Enum for specifying the strategy for metadata detection."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "1.3.5"
+version = "1.4.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Add the `enable_assets_returned_as_base64`, which allows the client to enable or disable returning document assets.