### PR TITLE
chore: Multiple minor changes

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from statistics import mean
 from typing import Any, Literal
-from urllib.parse import urljoin
 
 # 3rd party imports
 import httpx
@@ -196,7 +195,7 @@ class CompassClient:
         :param include_api_in_url: Whether to include '/api' in the base URL.
                Defaults to True.
         """
-        self.index_url = index_url
+        self.index_url = index_url if index_url.endswith("/") else f"{index_url}/"
         self.httpx_client = httpx.Client(timeout=DEFAULT_COMPASS_CLIENT_TIMEOUT)
 
         self.bearer_token = bearer_token
@@ -861,9 +860,9 @@ class CompassClient:
         http_method, api_path = API_DEFINITIONS[api_name]
 
         if self.include_api_in_url:
-            target_path = urljoin(self.index_url, f"api/v1/{api_path}")
+            target_path = f"{self.index_url}api/v1/{api_path}"
         else:
-            target_path = urljoin(self.index_url, f"v1/{api_path}")
+            target_path = f"{self.index_url}v1/{api_path}"
         target_path = target_path.format(**url_params)
 
         @retry(

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable
 from datetime import timedelta
 from statistics import mean
 from typing import Any, Literal
-from urllib.parse import urljoin
 
 # 3rd party imports
 import httpx
@@ -86,7 +85,7 @@ class CompassAsyncClient:
         :param include_api_in_url: Whether to include '/api' in the base URL.
                Defaults to True.
         """
-        self.index_url = index_url
+        self.index_url = index_url if index_url.endswith("/") else f"{index_url}/"
         self.httpx_client = httpx.AsyncClient(timeout=DEFAULT_COMPASS_CLIENT_TIMEOUT)
 
         self.bearer_token = bearer_token
@@ -753,9 +752,9 @@ class CompassAsyncClient:
         http_method, api_path = API_DEFINITIONS[api_name]
 
         if self.include_api_in_url:
-            target_path = urljoin(self.index_url, f"api/v1/{api_path}")
+            target_path = f"{self.index_url}api/v1/{api_path}"
         else:
-            target_path = urljoin(self.index_url, f"v1/{api_path}")
+            target_path = f"{self.index_url}v1/{api_path}"
         target_path = target_path.format(**url_params)
 
         @retry(

--- a/cohere_compass/clients/parser.py
+++ b/cohere_compass/clients/parser.py
@@ -377,13 +377,15 @@ class CompassParserClient:
 
         docs: list[CompassDocument] = []
         for doc in res.json()["docs"]:
-            if not doc.get("errors", []):
-                compass_doc = self._adapt_doc_id_compass_doc(doc)
-                additional_metadata = CompassParserClient._get_metadata(
-                    doc=compass_doc, custom_context=custom_context
-                )
-                compass_doc.content = {**compass_doc.content, **additional_metadata}
-                docs.append(compass_doc)
+            compass_doc = self._adapt_doc_id_compass_doc(doc)
+            if compass_doc.errors:
+                doc_id = compass_doc.metadata.document_id
+                logger.warning(f"Document {doc_id} has errors: {compass_doc.errors}")
+            additional_metadata = CompassParserClient._get_metadata(
+                doc=compass_doc, custom_context=custom_context
+            )
+            compass_doc.content = {**compass_doc.content, **additional_metadata}
+            docs.append(compass_doc)
 
         return docs
 

--- a/cohere_compass/clients/parser_async.py
+++ b/cohere_compass/clients/parser_async.py
@@ -379,13 +379,16 @@ class CompassParserAsyncClient:
 
         docs: list[CompassDocument] = []
         for doc in res.json()["docs"]:
-            if not doc.get("errors", []):
-                compass_doc = self._adapt_doc_id_compass_doc(doc)
-                additional_metadata = CompassParserAsyncClient._get_metadata(
-                    doc=compass_doc, custom_context=custom_context
-                )
-                compass_doc.content = {**compass_doc.content, **additional_metadata}
-                docs.append(compass_doc)
+            compass_doc = self._adapt_doc_id_compass_doc(doc)
+            if compass_doc.errors:
+                doc_id = compass_doc.metadata.document_id
+                logger.warning(f"Document {doc_id} has errors: {compass_doc.errors}")
+            additional_metadata = CompassParserAsyncClient._get_metadata(
+                doc=compass_doc, custom_context=custom_context
+            )
+            compass_doc.content = {**compass_doc.content, **additional_metadata}
+            compass_doc.errors = doc.get("errors", [])
+            docs.append(compass_doc)
 
         return docs
 

--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -182,6 +182,8 @@ class ParserConfig(BaseModel):
         PresentationParsingStrategy.Unstructured
     )
 
+    enable_assets_returned_as_base64: bool = True
+
 
 class MetadataStrategy(str, Enum):
     """Enum for specifying the strategy for metadata detection."""

--- a/examples/compass_sdk_examples/create_index.py
+++ b/examples/compass_sdk_examples/create_index.py
@@ -27,7 +27,6 @@ This script creates an index in Compass and inserts documents into it.
         "--folder-path",
         type=str,
         help="Specify the path to the folder containing documents to insert.",
-        required=True,
     )
 
     return parser.parse_args()
@@ -43,6 +42,10 @@ def main():
     print(f"Creating index '{index_name}'...")
     client.create_index(index_name=index_name)
     print(f"Index '{index_name}' created.")
+
+    if not folder_path:
+        print("No folder path provided. Skipping document insertion.")
+        return
 
     print(f"Inserting documents from {folder_path} into index '{index_name}'...")
     parser = get_compass_parser()


### PR DESCRIPTION
- Ingest files even if parsing had some errors; this is better than ignoring a file altogether.
- Fix URL generation for APIs.
- Add `enable_assets_returned_as_base64` flag to ParserConfig.
- For the `cerate_index` example, make the `folder_path` for files to be ingested optional (i.e. in case the user just wants to create an index without ingesting any data.)