### PR TITLE
fix: speed up tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from requests_mock import ANY as requests_mock_ANY
+from requests_mock import Mocker
+
+
+@pytest.fixture
+def requests_mock_200s(requests_mock: Mocker) -> Mocker:
+    requests_mock.register_uri(requests_mock_ANY, requests_mock_ANY)
+    return requests_mock

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -8,89 +8,89 @@ from cohere_compass.models.config import IndexConfig
 from cohere_compass.models.documents import DocumentAttributes
 
 
-def test_delete_url_formatted_with_doc_and_index(requests_mock: Mocker):
+def test_delete_url_formatted_with_doc_and_index(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.delete_document(index_name="test_index", document_id="test_id")
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/documents/test_id"
     )
-    assert requests_mock.request_history[0].method == "DELETE"
+    assert requests_mock_200s.request_history[0].method == "DELETE"
 
 
-def test_create_index_formatted_with_index(requests_mock: Mocker):
+def test_create_index_formatted_with_index(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.create_index(index_name="test_index")
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index"
     )
-    assert requests_mock.request_history[0].method == "PUT"
+    assert requests_mock_200s.request_history[0].method == "PUT"
 
 
-def test_create_index_with_index_config(requests_mock: Mocker):
+def test_create_index_with_index_config(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.create_index(
         index_name="test_index", index_config=IndexConfig(number_of_shards=5)
     )
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index"
     )
-    assert requests_mock.request_history[0].method == "PUT"
-    assert requests_mock.request_history[0].json() == {"number_of_shards": 5}
+    assert requests_mock_200s.request_history[0].method == "PUT"
+    assert requests_mock_200s.request_history[0].json() == {"number_of_shards": 5}
 
 
-def test_put_documents_payload_and_url_exist(requests_mock: Mocker):
+def test_put_documents_payload_and_url_exist(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.insert_docs(index_name="test_index", docs=iter([CompassDocument()]))
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/documents"
     )
-    assert requests_mock.request_history[0].method == "PUT"
-    assert "documents" in requests_mock.request_history[0].json()
+    assert requests_mock_200s.request_history[0].method == "PUT"
+    assert "documents" in requests_mock_200s.request_history[0].json()
 
 
-def test_put_document_payload_and_url_exist(requests_mock: Mocker):
+def test_put_document_payload_and_url_exist(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.insert_doc(index_name="test_index", doc=CompassDocument())
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/documents"
     )
-    assert requests_mock.request_history[0].method == "PUT"
-    assert "documents" in requests_mock.request_history[0].json()
+    assert requests_mock_200s.request_history[0].method == "PUT"
+    assert "documents" in requests_mock_200s.request_history[0].json()
 
 
-def test_list_indices_is_valid(requests_mock: Mocker):
+def test_list_indices_is_valid(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.list_indexes()
-    assert requests_mock.request_history[0].method == "GET"
-    assert requests_mock.request_history[0].url == "http://test.com/api/v1/indexes"
+    assert requests_mock_200s.request_history[0].method == "GET"
+    assert requests_mock_200s.request_history[0].url == "http://test.com/api/v1/indexes"
 
 
-def test_get_documents_is_valid(requests_mock: Mocker):
+def test_get_documents_is_valid(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.get_document(index_name="test_index", document_id="test_id")
-    assert requests_mock.request_history[0].method == "GET"
+    assert requests_mock_200s.request_history[0].method == "GET"
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/documents/test_id"
     )
 
 
-def test_refresh_is_valid(requests_mock: Mocker):
+def test_refresh_is_valid(requests_mock_200s: Mocker):
     compass = CompassClient(index_url="http://test.com")
     compass.refresh_index(index_name="test_index")
-    assert requests_mock.request_history[0].method == "POST"
+    assert requests_mock_200s.request_history[0].method == "POST"
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/_refresh"
     )
 
 
-def test_add_attributes_is_valid(requests_mock: Mocker):
+def test_add_attributes_is_valid(requests_mock_200s: Mocker):
     attrs = DocumentAttributes()
     attrs.fake = "context"
     compass = CompassClient(index_url="http://test.com")
@@ -99,32 +99,36 @@ def test_add_attributes_is_valid(requests_mock: Mocker):
         document_id="test_id",
         attributes=attrs,
     )
-    assert requests_mock.request_history[0].method == "POST"
+    assert requests_mock_200s.request_history[0].method == "POST"
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/documents/test_id/_add_attributes"
     )
-    assert requests_mock.request_history[0].body == b'{"fake": "context"}'
+    assert requests_mock_200s.request_history[0].body == b'{"fake": "context"}'
 
 
-def test_search_doc_handles_connection_aborted_error_correctly(requests_mock: Mocker):
+def test_search_doc_handles_connection_aborted_error_correctly(
+    requests_mock_200s: Mocker,
+):
     compass = CompassClient(index_url="http://test.com")
     url = "http://test.com/api/v1/indexes/test_index/documents/_search"
-    requests_mock.post(url, exc=ConnectionAbortedError)
+    requests_mock_200s.post(url, exc=ConnectionAbortedError)
     with pytest.raises(CompassClientError):
         compass.search_documents(index_name="test_index", query="test")
 
 
-def test_search_chunk_handles_connection_aborted_error_correctly(requests_mock: Mocker):
+def test_search_chunk_handles_connection_aborted_error_correctly(
+    requests_mock_200s: Mocker,
+):
     compass = CompassClient(index_url="http://test.com")
     url = "http://test.com/api/v1/indexes/test_index/documents/_search_chunks"
-    requests_mock.post(url, exc=ConnectionAbortedError)
+    requests_mock_200s.post(url, exc=ConnectionAbortedError)
     with pytest.raises(CompassClientError):
         compass.search_chunks(index_name="test_index", query="test")
 
 
-def test_get_document_asset_with_json_asset(requests_mock: Mocker):
-    requests_mock.get(
+def test_get_document_asset_with_json_asset(requests_mock_200s: Mocker):
+    requests_mock_200s.get(
         "http://test.com/api/v1/indexes/test_index/documents/test_id/assets/test_asset_id",
         json={"test": "test"},
         headers={"Content-Type": "application/json"},
@@ -138,8 +142,8 @@ def test_get_document_asset_with_json_asset(requests_mock: Mocker):
     assert content_type == "application/json"
 
 
-def test_get_document_asset_markdown(requests_mock: Mocker):
-    requests_mock.get(
+def test_get_document_asset_markdown(requests_mock_200s: Mocker):
+    requests_mock_200s.get(
         "http://test.com/api/v1/indexes/test_index/documents/test_id/assets/test_asset_id",
         text="# Test",
         headers={"Content-Type": "text/markdown"},
@@ -153,8 +157,8 @@ def test_get_document_asset_markdown(requests_mock: Mocker):
     assert content_type == "text/markdown"
 
 
-def test_get_document_asset_image(requests_mock: Mocker):
-    requests_mock.get(
+def test_get_document_asset_image(requests_mock_200s: Mocker):
+    requests_mock_200s.get(
         "http://test.com/api/v1/indexes/test_index/documents/test_id/assets/test_asset_id",
         content=b"test",
         headers={"Content-Type": "image/png"},
@@ -168,39 +172,39 @@ def test_get_document_asset_image(requests_mock: Mocker):
     assert content_type == "image/png"
 
 
-def test_direct_search_is_valid(requests_mock: Mocker):
+def test_direct_search_is_valid(requests_mock_200s: Mocker):
     # Register mock response for the direct_search endpoint
-    requests_mock.post(
+    requests_mock_200s.post(
         "http://test.com/api/v1/indexes/test_index/_direct_search",
         json={"hits": [], "scroll_id": "test_scroll_id"},
     )
 
     compass = CompassClient(index_url="http://test.com")
     compass.direct_search(index_name="test_index", query={"match_all": {}})
-    assert requests_mock.request_history[0].method == "POST"
+    assert requests_mock_200s.request_history[0].method == "POST"
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/test_index/_direct_search"
     )
-    assert "query" in requests_mock.request_history[0].json()
-    assert "size" in requests_mock.request_history[0].json()
+    assert "query" in requests_mock_200s.request_history[0].json()
+    assert "size" in requests_mock_200s.request_history[0].json()
 
 
-def test_direct_search_scroll_is_valid(requests_mock: Mocker):
+def test_direct_search_scroll_is_valid(requests_mock_200s: Mocker):
     # Register mock response for the direct_search_scroll endpoint
-    requests_mock.post(
+    requests_mock_200s.post(
         "http://test.com/api/v1/indexes/_direct_search/scroll",
         json={"hits": [], "scroll_id": "test_scroll_id"},
     )
 
     compass = CompassClient(index_url="http://test.com")
     compass.direct_search_scroll(scroll_id="test_scroll_id")
-    assert requests_mock.request_history[0].method == "POST"
+    assert requests_mock_200s.request_history[0].method == "POST"
     assert (
-        requests_mock.request_history[0].url
+        requests_mock_200s.request_history[0].url
         == "http://test.com/api/v1/indexes/_direct_search/scroll"
     )
-    request_body = requests_mock.request_history[0].json()
+    request_body = requests_mock_200s.request_history[0].json()
     assert request_body["scroll_id"] == "test_scroll_id"
     assert request_body["scroll"] == "1m"
 

--- a/tests/test_parser_client.py
+++ b/tests/test_parser_client.py
@@ -3,23 +3,27 @@ from requests_mock import Mocker
 from cohere_compass.clients import CompassParserClient
 
 
-def test_process_file_bytes(requests_mock: Mocker) -> None:
-    requests_mock.post("mock://test.com/v1/process_file", json={"docs": []})
+def test_process_file_bytes(requests_mock_200s: Mocker) -> None:
+    requests_mock_200s.post("mock://test.com/v1/process_file", json={"docs": []})
     client = CompassParserClient(parser_url="mock://test.com")
     client.process_file_bytes(filename="test.pdf", file_bytes=b"0")
-    assert requests_mock.request_history[0].method == "POST"
-    assert requests_mock.request_history[0].url == "mock://test.com/v1/process_file"
-    headers = requests_mock.request_history[0].headers
+    assert requests_mock_200s.request_history[0].method == "POST"
+    assert (
+        requests_mock_200s.request_history[0].url == "mock://test.com/v1/process_file"
+    )
+    headers = requests_mock_200s.request_history[0].headers
     assert "multipart/form-data" in headers["Content-Type"]
     assert "Authorization" not in headers
 
 
-def test_process_file_bytes_with_auth(requests_mock: Mocker) -> None:
-    requests_mock.post("mock://test.com/v1/process_file", json={"docs": []})
+def test_process_file_bytes_with_auth(requests_mock_200s: Mocker) -> None:
+    requests_mock_200s.post("mock://test.com/v1/process_file", json={"docs": []})
     client = CompassParserClient(parser_url="mock://test.com", bearer_token="secret")
     client.process_file_bytes(filename="test.pdf", file_bytes=b"0")
-    assert requests_mock.request_history[0].method == "POST"
-    assert requests_mock.request_history[0].url == "mock://test.com/v1/process_file"
-    headers = requests_mock.request_history[0].headers
+    assert requests_mock_200s.request_history[0].method == "POST"
+    assert (
+        requests_mock_200s.request_history[0].url == "mock://test.com/v1/process_file"
+    )
+    headers = requests_mock_200s.request_history[0].headers
     assert "multipart/form-data" in headers["Content-Type"]
     assert "Authorization" in headers


### PR DESCRIPTION
Problem: Tests take a long time due to retries+backoff because the requests mock returns unhappy responses by default.

Solution: Make the requests mock return all 200s, avoiding retries and
sleeps.

Before: `20 passed, 2 warnings in 90.47s (0:01:30)`
After: `20 passed, 2 warnings in 0.40s`
