### PR TITLE
feat: add sort to direct search

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -69,6 +69,7 @@ from cohere_compass.models import (
 from cohere_compass.models.config import IndexConfig
 from cohere_compass.models.datasources import PaginatedList
 from cohere_compass.models.documents import DocumentAttributes, PutDocumentsResponse
+from cohere_compass.models.search import SortBy
 
 
 @dataclass
@@ -998,6 +999,7 @@ class CompassClient:
         *,
         index_name: str,
         query: dict[str, Any],
+        sort_by: Optional[list[SortBy]] = None,
         size: int = 100,
         scroll: Optional[str] = None,
         max_retries: Optional[int] = None,
@@ -1016,7 +1018,7 @@ class CompassClient:
         :returns: the direct search results
         :raises CompassError: if the search fails
         """
-        data = DirectSearchInput(query=query, size=size, scroll=scroll)
+        data = DirectSearchInput(query=query, size=size, sort_by=sort_by, scroll=scroll)
 
         result = self._send_request(
             api_name="direct_search",

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -1,6 +1,6 @@
 # Python imports
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 # 3rd party imports
 from pydantic import BaseModel
@@ -87,11 +87,17 @@ class SearchInput(BaseModel):
     rerank_model: Optional[str] = None
 
 
+class SortBy(BaseModel):
+    field: str
+    order: Literal["asc", "desc"]
+
+
 class DirectSearchInput(BaseModel):
     """Input to direct search APIs."""
 
     query: dict[str, Any]
     size: int
+    sort_by: list[SortBy] | None = None
     scroll: Optional[str] = None
 
 

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -1,6 +1,6 @@
 # Python imports
 from enum import Enum
-from typing import Any, Literal, Optional, List
+from typing import Any, Literal, Optional
 
 # 3rd party imports
 from pydantic import BaseModel
@@ -99,7 +99,7 @@ class DirectSearchInput(BaseModel):
 
     query: dict[str, Any]
     size: int
-    sort_by: Optional[List[SortBy]] = None
+    sort_by: Optional[list[SortBy]] = None
     scroll: Optional[str] = None
 
 

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -88,6 +88,8 @@ class SearchInput(BaseModel):
 
 
 class SortBy(BaseModel):
+    """Specifies sorting options for search results."""
+
     field: str
     order: Literal["asc", "desc"]
 

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -1,6 +1,6 @@
 # Python imports
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, List
 
 # 3rd party imports
 from pydantic import BaseModel
@@ -99,7 +99,7 @@ class DirectSearchInput(BaseModel):
 
     query: dict[str, Any]
     size: int
-    sort_by: list[SortBy] | None = None
+    sort_by: Optional[List[SortBy]] = None
     scroll: Optional[str] = None
 
 

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -7,6 +7,7 @@ from cohere_compass.exceptions import CompassClientError
 from cohere_compass.models import CompassDocument
 from cohere_compass.models.config import IndexConfig
 from cohere_compass.models.documents import CompassDocumentMetadata, DocumentAttributes
+from cohere_compass.models.search import SortBy
 
 
 def test_delete_url_formatted_with_doc_and_index(requests_mock_200s: Mocker):
@@ -244,6 +245,74 @@ def test_direct_search_scroll_is_valid(requests_mock_200s: Mocker):
     request_body = requests_mock_200s.request_history[0].json()
     assert request_body["scroll_id"] == "test_scroll_id"
     assert request_body["scroll"] == "1m"
+
+
+def test_direct_search_with_sort_by_single_field(requests_mock_200s: Mocker):
+    # Register mock response for the direct_search endpoint
+    requests_mock_200s.post(
+        "http://test.com/api/v1/indexes/test_index/_direct_search",
+        json={"hits": [], "scroll_id": "test_scroll_id"},
+    )
+
+    compass = CompassClient(index_url="http://test.com")
+    sort_by = [SortBy(field="created_at", order="desc")]
+    compass.direct_search(
+        index_name="test_index", query={"match_all": {}}, sort_by=sort_by
+    )
+    assert requests_mock_200s.request_history[0].method == "POST"
+    assert (
+        requests_mock_200s.request_history[0].url
+        == "http://test.com/api/v1/indexes/test_index/_direct_search"
+    )
+    payload = requests_mock_200s.request_history[0].json()
+    assert "sort_by" in payload
+    assert payload["sort_by"] == [{"field": "created_at", "order": "desc"}]
+
+
+def test_direct_search_with_sort_by_multiple_fields(requests_mock_200s: Mocker):
+    # Register mock response for the direct_search endpoint
+    requests_mock_200s.post(
+        "http://test.com/api/v1/indexes/test_index/_direct_search",
+        json={"hits": [], "scroll_id": "test_scroll_id"},
+    )
+
+    compass = CompassClient(index_url="http://test.com")
+    sort_by = [
+        SortBy(field="created_at", order="desc"),
+        SortBy(field="score", order="asc"),
+    ]
+    compass.direct_search(
+        index_name="test_index", query={"match_all": {}}, sort_by=sort_by
+    )
+    assert requests_mock_200s.request_history[0].method == "POST"
+    assert (
+        requests_mock_200s.request_history[0].url
+        == "http://test.com/api/v1/indexes/test_index/_direct_search"
+    )
+    payload = requests_mock_200s.request_history[0].json()
+    assert "sort_by" in payload
+    assert payload["sort_by"] == [
+        {"field": "created_at", "order": "desc"},
+        {"field": "score", "order": "asc"},
+    ]
+
+
+def test_direct_search_without_sort_by(requests_mock_200s: Mocker):
+    # Register mock response for the direct_search endpoint
+    requests_mock_200s.post(
+        "http://test.com/api/v1/indexes/test_index/_direct_search",
+        json={"hits": [], "scroll_id": "test_scroll_id"},
+    )
+
+    compass = CompassClient(index_url="http://test.com")
+    compass.direct_search(index_name="test_index", query={"match_all": {}})
+    assert requests_mock_200s.request_history[0].method == "POST"
+    assert (
+        requests_mock_200s.request_history[0].url
+        == "http://test.com/api/v1/indexes/test_index/_direct_search"
+    )
+    payload = requests_mock_200s.request_history[0].json()
+    assert "sort_by" not in payload or payload["sort_by"] is None
 
 
 def test_proper_handling_of_returned_tuple_from_parser():


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR introduces the `SortBy` class and adds the `sort_by` parameter to the `direct_search` function.

## Changes
- The `SortBy` class is added to the `cohere_compass.models.search` module. It has two fields: `field` and `order`.
- The `sort_by` parameter is added to the `direct_search` function in the `cohere_compass.clients.compass` module.
- The `DirectSearchInput` class is updated to include the `sort_by` field.
- The `data` variable in the `direct_search` function is updated to include the `sort_by` parameter.

<!-- end-generated-description -->