### PR TITLE
feat: Adding asset id to returned chunk

### DIFF
--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -52,6 +52,7 @@ class CompassDocumentChunkAsset(BaseModel):
     asset_type: AssetType
     content_type: str
     asset_data: str
+    asset_id: Optional[str] = None
 
 
 class CompassDocumentChunk(ValidatedModel):
@@ -238,6 +239,7 @@ class DocumentChunkAsset(BaseModel):
     asset_type: AssetType
     content_type: str
     asset_data: str
+    asset_id: Optional[str] = None
 
 
 class Chunk(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "1.5.0"
+version = "1.6.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR introduces a new field, `asset_id`, to the `CompassDocumentChunkAsset` and `DocumentChunkAsset` classes.

## Changes
- The `asset_id` field is added to the `CompassDocumentChunkAsset` class as an optional string with a default value of `None`.
- The `asset_id` field is added to the `DocumentChunkAsset` class as an optional string with a default value of `None`.

<!-- end-generated-description -->