### PR TITLE
fix: Adding error log when parser fails on doc level

### DIFF
--- a/cohere_compass/clients/parser.py
+++ b/cohere_compass/clients/parser.py
@@ -401,7 +401,9 @@ class CompassParserClient:
 
         docs: list[CompassDocument] = []
         for doc in res.json()["docs"]:
-            if not doc.get("errors", []):
+            if doc.get("errors"):
+                logger.error(f"Error processing file {filename}: {doc['errors']}")
+            else:
                 compass_doc = CompassDocument.adapt_doc_id_compass_doc(doc)
                 additional_metadata = CompassParserClient._get_metadata(
                     doc=compass_doc, custom_context=custom_context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "1.7.0"
+version = "1.7.1"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Previously, if a document failed during parsing, the error was silently ignored and only the successfully parsed documents were returned.
This PR introduces error logging so that any document-specific parsing failures are now recorded, making issues more visible while continuing to return the successfully parsed documents.