### PR TITLE
chore: update package name to match v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "compass-sdk"
+name = "cohere-compass-sdk"
 version = "2.0.0"
 authors = []
 description = "Cohere Compass SDK"


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR renames the tool.poetry name from "compass-sdk" to "cohere-compass-sdk".

## Changes
- The name field in tool.poetry has been updated from "compass-sdk" to "cohere-compass-sdk".

<!-- end-generated-description -->