### PR TITLE
chore: bump version to 2.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.8.0"
+version = "2.8.1"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the pyproject.toml file by changing the version number and reformatting the omit list.

- The version number has been updated from 2.8.0 to 2.8.1.
- The omit list has been reformatted from a list of strings to a single string with commas.

<!-- end-generated-description -->