### PR TITLE
feat: Adding webp to image assets for downloading

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -1493,7 +1493,7 @@ class CompassClient:
         response.raise_for_status()
 
         content_type = response.headers.get("content-type")
-        if content_type in ("image/jpeg", "image/png"):
+        if content_type in ("image/jpeg", "image/png", "image/webp"):
             # To handle response from get_document_asset() when the asset
             # is an image.
             result = response.content

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -1360,7 +1360,7 @@ class CompassAsyncClient:
         response.raise_for_status()
 
         content_type = response.headers.get("content-type")
-        if content_type in ("image/jpeg", "image/png"):
+        if content_type in ("image/jpeg", "image/png", "image/webp"):
             # To handle response from get_document_asset() when the asset
             # is an image.
             result = response.content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.9.0"
+version = "2.9.1"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `_send_http_request` function in the `cohere_compass/clients/compass.py` and `cohere_compass/clients/compass_async.py` files.

- The function now checks for the `image/webp` content type in addition to `image/jpeg` and `image/png`.
- This change ensures that the function can handle responses from `get_document_asset()` when the asset is an image in WebP format.

<!-- end-generated-description -->