### PR TITLE
feat: Adding audio, video to sdk assets

### DIFF
--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -47,6 +47,10 @@ class AssetType(str, Enum):
     # A dump of the text extracted from a document
     DOCUMENT_TEXT = "document_text"
 
+    VIDEO = "video"
+
+    AUDIO = "audio"
+
 
 class CompassDocumentChunkAsset(BaseModel):
     """An asset associated with a Compass document chunk."""

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -26,7 +26,7 @@ class AssetInfo(BaseModel):
     asset_id: str | None = None
     asset_type: AssetType
     content_type: str
-    presigned_url: str
+    presigned_url: str | None = None
     visual_elements: list[VisualElement] | None = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.10.0"
+version = "2.11.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `cohere-compass-sdk` to version 2.11.0.

- `cohere_compass/models/documents.py` adds `VIDEO` and `AUDIO` to the `AssetType` enum.
- `cohere_compass/models/search.py` changes the `presigned_url` field in the `AssetInfo` class to be optional.
- `pyproject.toml` updates the version from 2.10.0 to 2.11.0.

<!-- end-generated-description -->