### PR TITLE
fix: unwrap retention_policy envelope in get_retention_policy

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -527,7 +527,18 @@ class CompassClient:
         if result.result is None:
             return None
 
-        return RetentionPolicy.model_validate(result.result)
+        # The server wraps the policy in an envelope: {"retention_policy": {...}}.
+        # Fall back to the raw payload to remain compatible with any deployment that
+        # returns the bare policy.
+        policy_data = (
+            result.result.get("retention_policy")
+            if isinstance(result.result, dict) and "retention_policy" in result.result
+            else result.result
+        )
+        if policy_data is None:
+            return None
+
+        return RetentionPolicy.model_validate(policy_data)
 
     def delete_retention_policy(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -386,7 +386,18 @@ class CompassAsyncClient:
         if result.result is None:
             return None
 
-        return RetentionPolicy.model_validate(result.result)
+        # The server wraps the policy in an envelope: {"retention_policy": {...}}.
+        # Fall back to the raw payload to remain compatible with any deployment that
+        # returns the bare policy.
+        policy_data = (
+            result.result.get("retention_policy")
+            if isinstance(result.result, dict) and "retention_policy" in result.result
+            else result.result
+        )
+        if policy_data is None:
+            return None
+
+        return RetentionPolicy.model_validate(policy_data)
 
     async def delete_retention_policy(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.11.0"
+version = "2.11.1"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -29,7 +29,12 @@ from cohere_compass.models.documents import (
     DocumentAttributes,
     UploadDocumentsResult,
 )
-from cohere_compass.models.indexes import IndexDetails, IndexInfo
+from cohere_compass.models.indexes import (
+    IndexDetails,
+    IndexInfo,
+    RetentionPolicy,
+    RetentionType,
+)
 from cohere_compass.models.search import (
     SortBy,
 )
@@ -982,3 +987,83 @@ def test_get_asset_presigned_urls_success(client: CompassClient, respx_mock: Moc
     assert result[1].document_id == "doc_456"
     assert result[1].asset_id == asset_b_uuid
     assert result[1].presigned_url == "https://example.com/asset_B?X-Amz-Signature=..."
+
+
+# Retention policy tests
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/retention",
+    200,
+    response_body={
+        "retention_policy": {
+            "retention_type": "sliding",
+            "ttl_days": 365,
+            "grace_period_days": 7,
+            "enabled": True,
+        }
+    },
+)
+def test_get_retention_policy_unwraps_envelope(client: CompassClient):
+    # Regression test for https://github.com/cohere-ai/cohere-compass-sdk/issues/204:
+    # the server wraps the policy under a `retention_policy` key, which used to
+    # raise a pydantic ValidationError.
+    policy = client.get_retention_policy(index_name="test_index")
+
+    assert policy == RetentionPolicy(
+        retention_type=RetentionType.Sliding,
+        ttl_days=365,
+        grace_period_days=7,
+        enabled=True,
+    )
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/retention",
+    200,
+    response_body={"retention_policy": None},
+)
+def test_get_retention_policy_returns_none_when_envelope_null(client: CompassClient):
+    assert client.get_retention_policy(index_name="test_index") is None
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/retention",
+    200,
+    response_body=None,
+)
+def test_get_retention_policy_returns_none_when_body_empty(client: CompassClient):
+    assert client.get_retention_policy(index_name="test_index") is None
+
+
+@mock_endpoint(
+    "PUT",
+    "http://test.com/v1/indexes/test_index/retention",
+    200,
+    expected_request_body={
+        "retention_type": "fixed",
+        "ttl_days": 30,
+        "grace_period_days": 7,
+        "enabled": True,
+    },
+)
+def test_set_retention_policy_sends_correct_body(client: CompassClient):
+    client.set_retention_policy(
+        index_name="test_index",
+        retention_policy=RetentionPolicy(
+            retention_type=RetentionType.Fixed,
+            ttl_days=30,
+        ),
+    )
+
+
+@mock_endpoint(
+    "DELETE",
+    "http://test.com/v1/indexes/test_index/retention",
+    200,
+)
+def test_delete_retention_policy_sends_request(client: CompassClient):
+    client.delete_retention_policy(index_name="test_index")


### PR DESCRIPTION
## Summary

Fixes #204.

`CompassClient.get_retention_policy()` (and the async equivalent) was passing the full server response envelope to `RetentionPolicy.model_validate()`, which raised a `pydantic.ValidationError` because `retention_type` / `ttl_days` aren't top-level keys — they're nested under `retention_policy`:

```json
{ "retention_policy": { "retention_type": "sliding", "ttl_days": 365, "grace_period_days": 7, "enabled": true } }
```

### Changes

- `cohere_compass/clients/compass.py` + `compass_async.py`: unwrap the `retention_policy` key before validating. Falls back to the raw payload if the key isn't present, so any deployment returning the bare body keeps working. A null/missing inner value is treated as "no policy configured" and returns `None`.
- `tests/test_compass_client.py`: regression tests for the envelope case, null envelope, empty body, and the `set` / `delete` request shapes. Tests run against both sync and async clients via the existing `client` fixture.
- `pyproject.toml`: version bumped `2.11.0` → `2.11.1` (required by the version-bump CI check).

### Out of scope

The issue's "Additional information" mentions `GET /indexes/<index>` returning `retention_policy: null` even when a policy is set. That looks like a server-side issue on the reporter's standalone Compass instance — the SDK side (`IndexDetails.retention_policy: RetentionPolicy | None`) is already correct, so it isn't addressed here.

## Test plan

- [x] `pytest tests/test_compass_client.py -k retention` — **10 passed** (5 tests × sync/async)
- [x] Full local test suite — **176 passed**
- [x] Verified regression coverage by temporarily reverting the fix: the two envelope-related tests fail with the exact `ValidationError` from #204; restoring the fix makes them pass again
- [x] Full test suite green in CI
- [x] `Require Version Bump` CI check passes (2.11.0 → 2.11.1)