### PR TITLE
feat: update compass api, adding presigned url for cropped images and media. Adding upload pre-signed url

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -775,7 +775,7 @@ class CompassClient:
         :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
-        :param document_id: The ID to assign to the document (optional).
+        :param document_id: The ID to assign to the document.
         :param attributes: Additional attributes to add to the document.
         :param config: Configuration for the document parsing.
         :param authorized_groups: When Document-level Security is enabled,
@@ -816,13 +816,12 @@ class CompassClient:
                 config=config,
             )
         else:
-            if content_length_bytes is None:
-                raise ValueError("`content_length_bytes` is required when using `file_data_uuid`.")
             doc = ParseableDocument(
                 id=document_id,
                 filename=filename,
                 content_type=content_type,
-                content_length_bytes=content_length_bytes,
+                # This is calculated by the client when file_uuid is provided.
+                content_length_bytes=content_length_bytes or 0,
                 file_data_uuid=file_data_uuid,
                 attributes=attributes,
                 config=config,
@@ -847,7 +846,6 @@ class CompassClient:
         self,
         *,
         index_name: str,
-        filename: str,
         content_type: ContentTypeEnum,
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
@@ -879,7 +877,6 @@ class CompassClient:
             api_name="get_upload_presigned_url",
             index_name=index_name,
             data=UploadFilePresignedUrlRequest(
-                filename=filename,
                 content_type=content_type,
             ),
             max_retries=max_retries,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -780,7 +780,7 @@ class CompassClient:
         :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
-        :param document_id: The ID to assign to the document.
+        :param document_id: The ID to assign to the document (optional).
         :param attributes: Additional attributes to add to the document.
         :param config: Configuration for the document parsing.
         :param authorized_groups: When Document-level Security is enabled,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -817,7 +817,6 @@ class CompassClient:
         index_name: str,
         filename: str,
         file_data_uuid: uuid.UUID,
-        content_length_bytes: int,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -839,8 +838,6 @@ class CompassClient:
         :param filename: The filename of the document.
         :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
         :param content_length_bytes: The size of the uploaded file in bytes.
-        :param content_type: optional content type of the document.
-            Recommended to pass it otherwise auto-detected.
         :param document_id: The ID to assign to the document.
         :param attributes: Additional attributes to add to the document.
         :param config: Configuration for the document parsing.
@@ -864,7 +861,6 @@ class CompassClient:
             id=document_id,
             filename=filename,
             content_type=content_type,
-            content_length_bytes=content_length_bytes,
             file_data_uuid=file_data_uuid,
             attributes=attributes,
             config=config,
@@ -890,6 +886,7 @@ class CompassClient:
         *,
         index_name: str,
         content_type: ContentTypeEnum,
+        filename: str,
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
@@ -921,6 +918,7 @@ class CompassClient:
             index_name=index_name,
             data=UploadFilePresignedUrlRequest(
                 content_type=content_type,
+                filename=filename,
             ),
             max_retries=max_retries,
             retry_wait=retry_wait,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -745,8 +745,7 @@ class CompassClient:
         *,
         index_name: str,
         filename: str,
-        filebytes: bytes | None = None,
-        file_data_uuid: uuid.UUID | None = None,
+        filebytes: bytes,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -758,18 +757,13 @@ class CompassClient:
         timeout: timedelta | None = None,
     ) -> UploadDocumentsResult:
         """
-        Parse and insert a document into an index in Compass.
+        Parse and insert a document into an index in Compass using raw bytes.
 
-        Provide exactly one of ``filebytes`` or ``file_data_uuid``:
-
-        - **filebytes**: the raw document bytes (will be base64-encoded and sent inline).
-        - **file_data_uuid**: a UUID returned by ``get_upload_presigned_url`` after
-          the client has already PUT the file bytes to object storage.
+        The document bytes are base64-encoded and sent inline in the request.
 
         :param index_name: The name of the index.
         :param filename: The filename of the document.
         :param filebytes: The raw bytes of the document.
-        :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
         :param document_id: The ID to assign to the document.
@@ -790,36 +784,91 @@ class CompassClient:
         Returns:
             UploadDocumentsResult containing the upload ID and status.
 
-        Raises:
-            ValueError: If both or neither of ``filebytes`` and ``file_data_uuid``
-                are provided.
+        """
+        b64 = base64.b64encode(filebytes).decode("utf-8")
+        doc = ParseableDocument(
+            id=document_id,
+            filename=filename,
+            content_type=content_type,
+            content_length_bytes=len(filebytes),
+            content_encoded_bytes=b64,
+            attributes=attributes,
+            config=config,
+        )
+
+        result = self._send_request(
+            api_name="upload_documents",
+            data=UploadDocumentsInput(
+                documents=[doc],
+                authorized_groups=authorized_groups,
+                merge_groups_on_conflict=merge_groups_on_conflict,
+            ),
+            index_name=index_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+
+        return UploadDocumentsResult.model_validate(result.result)
+
+    def upload_document_via_uuid(
+        self,
+        *,
+        index_name: str,
+        filename: str,
+        file_data_uuid: uuid.UUID,
+        content_length_bytes: int,
+        document_id: str,
+        attributes: DocumentAttributes = DocumentAttributes(),
+        config: ParseableDocumentConfig = ParseableDocumentConfig(),
+        content_type: ContentTypeEnum | None = None,
+        authorized_groups: list[str] | None = None,
+        merge_groups_on_conflict: bool = False,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> UploadDocumentsResult:
+        """
+        Parse and insert a document into an index in Compass using a pre-uploaded file.
+
+        Use this method when the file bytes have already been uploaded to object
+        storage via ``get_upload_presigned_url``. Pass the ``file_data_uuid``
+        returned by that call.
+
+        :param index_name: The name of the index.
+        :param filename: The filename of the document.
+        :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
+        :param content_length_bytes: The size of the uploaded file in bytes.
+        :param content_type: optional content type of the document.
+            Recommended to pass it otherwise auto-detected.
+        :param document_id: The ID to assign to the document.
+        :param attributes: Additional attributes to add to the document.
+        :param config: Configuration for the document parsing.
+        :param authorized_groups: When Document-level Security is enabled,
+            Set authorized user groups to access the document.
+            These groups should exist in RBAC. Default will make the document public.
+        :param merge_groups_on_conflict: When Document-level Security is enabled,
+            allows merging authorized groups if document already exists.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            UploadDocumentsResult containing the upload ID and status.
 
         """
-        if filebytes is not None and file_data_uuid is not None:
-            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`, not both.")
-        if filebytes is None and file_data_uuid is None:
-            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`.")
-
-        if filebytes is not None:
-            b64 = base64.b64encode(filebytes).decode("utf-8")
-            doc = ParseableDocument(
-                id=document_id,
-                filename=filename,
-                content_type=content_type,
-                content_length_bytes=len(filebytes),
-                content_encoded_bytes=b64,
-                attributes=attributes,
-                config=config,
-            )
-        else:
-            doc = ParseableDocument(
-                id=document_id,
-                filename=filename,
-                content_type=content_type,
-                file_data_uuid=file_data_uuid,
-                attributes=attributes,
-                config=config,
-            )
+        doc = ParseableDocument(
+            id=document_id,
+            filename=filename,
+            content_type=content_type,
+            content_length_bytes=content_length_bytes,
+            file_data_uuid=file_data_uuid,
+            attributes=attributes,
+            config=config,
+        )
 
         result = self._send_request(
             api_name="upload_documents",
@@ -850,8 +899,8 @@ class CompassClient:
 
         Returns a presigned URL that can be used to PUT raw file bytes directly to
         storage, plus a ``file_data_uuid`` that can later be passed to
-        ``upload_document`` (via the ``file_data_uuid`` parameter) to ingest the
-        uploaded file without re-sending its bytes through the API.
+        ``upload_document_via_uuid`` to ingest the uploaded file without
+        re-sending its bytes through the API.
 
         :param index_name: The name of the index the file will be uploaded to.
         :param filename: The filename of the document to be uploaded.

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -78,6 +78,8 @@ from cohere_compass.models.documents import (
     ParsedDocumentResponse,
     PutDocumentsResponse,
     UploadDocumentsStatus,
+    UploadFilePresignedUrlRequest,
+    UploadFilePresignedUrlResponse,
 )
 from cohere_compass.models.indexes import IndexDetails, ListIndexesResponse, RetentionPolicy
 from cohere_compass.models.search import (
@@ -169,6 +171,10 @@ API_DEFINITIONS = {
     "upload_documents": (
         "POST",
         "indexes/{index_name}/documents/upload",
+    ),
+    "get_upload_presigned_url": (
+        "POST",
+        "indexes/{index_name}/documents/upload/presigned_url",
     ),
     "upload_documents_status": (
         "GET",
@@ -733,7 +739,9 @@ class CompassClient:
         *,
         index_name: str,
         filename: str,
-        filebytes: bytes,
+        filebytes: bytes | None = None,
+        file_data_uuid: uuid.UUID | None = None,
+        content_length_bytes: int | None = None,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -747,9 +755,18 @@ class CompassClient:
         """
         Parse and insert a document into an index in Compass.
 
+        Provide exactly one of ``filebytes`` or ``file_data_uuid``:
+
+        - **filebytes**: the raw document bytes (will be base64-encoded and sent inline).
+        - **file_data_uuid**: a UUID returned by ``get_upload_presigned_url`` after
+          the client has already PUT the file bytes to object storage. When using this
+          path, ``content_length_bytes`` must also be supplied.
+
         :param index_name: The name of the index.
         :param filename: The filename of the document.
         :param filebytes: The raw bytes of the document.
+        :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
+        :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
         :param document_id: The ID to assign to the document.
@@ -770,17 +787,40 @@ class CompassClient:
         Returns:
             UploadDocumentsResult containing the upload ID and status.
 
+        Raises:
+            ValueError: If both or neither of ``filebytes`` and ``file_data_uuid``
+                are provided, or if ``content_length_bytes`` is missing when using
+                ``file_data_uuid``.
+
         """
-        b64 = base64.b64encode(filebytes).decode("utf-8")
-        doc = ParseableDocument(
-            id=document_id,
-            filename=filename,
-            content_type=content_type,
-            content_length_bytes=len(filebytes),
-            content_encoded_bytes=b64,
-            attributes=attributes,
-            config=config,
-        )
+        if filebytes is not None and file_data_uuid is not None:
+            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`, not both.")
+        if filebytes is None and file_data_uuid is None:
+            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`.")
+
+        if filebytes is not None:
+            b64 = base64.b64encode(filebytes).decode("utf-8")
+            doc = ParseableDocument(
+                id=document_id,
+                filename=filename,
+                content_type=content_type,
+                content_length_bytes=len(filebytes),
+                content_encoded_bytes=b64,
+                attributes=attributes,
+                config=config,
+            )
+        else:
+            if content_length_bytes is None:
+                raise ValueError("`content_length_bytes` is required when using `file_data_uuid`.")
+            doc = ParseableDocument(
+                id=document_id,
+                filename=filename,
+                content_type=content_type,
+                content_length_bytes=content_length_bytes,
+                file_data_uuid=file_data_uuid,
+                attributes=attributes,
+                config=config,
+            )
 
         result = self._send_request(
             api_name="upload_documents",
@@ -796,6 +836,51 @@ class CompassClient:
         )
 
         return UploadDocumentsResult.model_validate(result.result)
+
+    def get_upload_presigned_url(
+        self,
+        *,
+        index_name: str,
+        filename: str,
+        content_type: ContentTypeEnum,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> UploadFilePresignedUrlResponse:
+        """
+        Get a presigned URL to upload a file directly to object storage.
+
+        Returns a presigned URL that can be used to PUT raw file bytes directly to
+        storage, plus a ``file_data_uuid`` that can later be passed to
+        ``upload_document`` (via the ``file_data_uuid`` parameter) to ingest the
+        uploaded file without re-sending its bytes through the API.
+
+        :param index_name: The name of the index the file will be uploaded to.
+        :param filename: The filename of the document to be uploaded.
+        :param content_type: The content type (MIME type) of the document. The client
+            must send the same value as the Content-Type header when PUTting bytes to
+            the returned presigned URL.
+        :param max_retries: Maximum number of retries for failed requests.
+        :param retry_wait: Time to wait between retries.
+        :param timeout: Request timeout duration.
+
+        Returns:
+            UploadFilePresignedUrlResponse containing the presigned URL, file_data_uuid,
+            expiration, and content type.
+
+        """
+        result = self._send_request(
+            api_name="get_upload_presigned_url",
+            index_name=index_name,
+            data=UploadFilePresignedUrlRequest(
+                filename=filename,
+                content_type=content_type,
+            ),
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return UploadFilePresignedUrlResponse.model_validate(result.result)
 
     def upload_document_status(
         self,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -210,11 +210,6 @@ API_DEFINITIONS = {
         "GET",
         "tasks/{task_id}",
     ),
-    # Get visual element from asset
-    "get_visual_element": (
-        "GET",
-        "indexes/{index_name}/documents/{document_id}/assets/{asset_id}",
-    ),
     # Retention Policy APIs
     "set_retention_policy": (
         "PUT",
@@ -1528,7 +1523,7 @@ class CompassClient:
 
         """
         result = self._send_request(
-            api_name="get_visual_element",
+            api_name="get_document_asset",
             index_name=index_name,
             document_id=document_id,
             asset_id=asset_id,
@@ -1582,7 +1577,7 @@ class CompassClient:
 
         """
         result = self._send_request(
-            api_name="get_visual_element",
+            api_name="get_document_asset",
             index_name=index_name,
             document_id=document_id,
             asset_id=asset_id,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -1540,6 +1540,60 @@ class CompassClient:
 
         return result.result, result.content_type  # type: ignore
 
+    def get_media_clip(
+        self,
+        *,
+        index_name: str,
+        document_id: str,
+        asset_id: str,
+        start_time: float,
+        end_time: float,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> tuple[str | bytes | dict[str, Any], str]:
+        """
+        Get an audio or video clip from a document asset in Compass.
+
+        Extracts a segment of an audio or video asset between ``start_time`` and
+        ``end_time`` (in seconds). The asset must be of type AUDIO (returns WAV)
+        or VIDEO (returns MP4). The server caps the segment duration at 15 minutes.
+
+        :param index_name: the name of the index
+        :param document_id: the id of the document
+        :param asset_id: the id of the asset
+        :param start_time: start time in seconds for the clip
+        :param end_time: end time in seconds for the clip
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A tuple of the clip bytes and the content type string (e.g.
+            ``"audio/wav"`` or ``"video/mp4"``).
+
+        Raises:
+            CompassError: if the clip cannot be retrieved, either because the asset
+                doesn't exist, is not an audio/video asset, or the user doesn't have
+                permission to access it.
+
+        """
+        result = self._send_request(
+            api_name="get_visual_element",
+            index_name=index_name,
+            document_id=document_id,
+            asset_id=asset_id,
+            query_params={"start_time": start_time, "end_time": end_time},
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+
+        return result.result, result.content_type  # type: ignore
+
     def _send_http_request(
         self,
         http_method: str,
@@ -1597,8 +1651,9 @@ class CompassClient:
             # To handle response from get_document_asset() when the asset
             # is a markdown.
             result = response.text
+        elif content_type is not None and (content_type.startswith("audio/") or content_type.startswith("video/")):
+            result = response.content
         else:
-            # To handle response from other APIs.
             result = response.json() if response.text else None
         return _SendRequestResult(
             result=result,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -747,7 +747,6 @@ class CompassClient:
         filename: str,
         filebytes: bytes | None = None,
         file_data_uuid: uuid.UUID | None = None,
-        content_length_bytes: int | None = None,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -765,14 +764,12 @@ class CompassClient:
 
         - **filebytes**: the raw document bytes (will be base64-encoded and sent inline).
         - **file_data_uuid**: a UUID returned by ``get_upload_presigned_url`` after
-          the client has already PUT the file bytes to object storage. When using this
-          path, ``content_length_bytes`` must also be supplied.
+          the client has already PUT the file bytes to object storage.
 
         :param index_name: The name of the index.
         :param filename: The filename of the document.
         :param filebytes: The raw bytes of the document.
         :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
-        :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
         :param document_id: The ID to assign to the document.
@@ -795,8 +792,7 @@ class CompassClient:
 
         Raises:
             ValueError: If both or neither of ``filebytes`` and ``file_data_uuid``
-                are provided, or if ``content_length_bytes`` is missing when using
-                ``file_data_uuid``.
+                are provided.
 
         """
         if filebytes is not None and file_data_uuid is not None:
@@ -820,8 +816,6 @@ class CompassClient:
                 id=document_id,
                 filename=filename,
                 content_type=content_type,
-                # This is calculated by the client when file_uuid is provided.
-                content_length_bytes=content_length_bytes or 0,
                 file_data_uuid=file_data_uuid,
                 attributes=attributes,
                 config=config,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -601,8 +601,7 @@ class CompassAsyncClient:
         *,
         index_name: str,
         filename: str,
-        filebytes: bytes | None = None,
-        file_data_uuid: uuid.UUID | None = None,
+        filebytes: bytes,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -614,18 +613,13 @@ class CompassAsyncClient:
         timeout: timedelta | None = None,
     ) -> UploadDocumentsResult:
         """
-        Parse and insert a document into an index in Compass.
+        Parse and insert a document into an index in Compass using raw bytes.
 
-        Provide exactly one of ``filebytes`` or ``file_data_uuid``:
-
-        - **filebytes**: the raw document bytes (will be base64-encoded and sent inline).
-        - **file_data_uuid**: a UUID returned by ``get_upload_presigned_url`` after
-          the client has already PUT the file bytes to object storage.
+        The document bytes are base64-encoded and sent inline in the request.
 
         :param index_name: the name of the index
         :param filename: the filename of the document
         :param filebytes: the bytes of the document
-        :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
         :param document_id: the id of the document.
@@ -646,36 +640,91 @@ class CompassAsyncClient:
         Returns:
             UploadDocumentsResult object containing the result of the upload
 
-        Raises:
-            ValueError: If both or neither of ``filebytes`` and ``file_data_uuid``
-                are provided
+        """
+        b64 = base64.b64encode(filebytes).decode("utf-8")
+        doc = ParseableDocument(
+            id=document_id,
+            filename=filename,
+            content_type=content_type,
+            content_length_bytes=len(filebytes),
+            content_encoded_bytes=b64,
+            attributes=attributes,
+            config=config,
+        )
+
+        result = await self._send_request(
+            api_name="upload_documents",
+            data=UploadDocumentsInput(
+                documents=[doc],
+                authorized_groups=authorized_groups,
+                merge_groups_on_conflict=merge_groups_on_conflict,
+            ),
+            index_name=index_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+
+        return UploadDocumentsResult.model_validate(result.result)
+
+    async def upload_document_via_uuid(
+        self,
+        *,
+        index_name: str,
+        filename: str,
+        file_data_uuid: uuid.UUID,
+        content_length_bytes: int,
+        document_id: str,
+        attributes: DocumentAttributes = DocumentAttributes(),
+        config: ParseableDocumentConfig = ParseableDocumentConfig(),
+        content_type: ContentTypeEnum | None = None,
+        authorized_groups: list[str] | None = None,
+        merge_groups_on_conflict: bool = False,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> UploadDocumentsResult:
+        """
+        Parse and insert a document into an index in Compass using a pre-uploaded file.
+
+        Use this method when the file bytes have already been uploaded to object
+        storage via ``get_upload_presigned_url``. Pass the ``file_data_uuid``
+        returned by that call.
+
+        :param index_name: the name of the index
+        :param filename: the filename of the document
+        :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
+        :param content_length_bytes: The size of the uploaded file in bytes.
+        :param content_type: optional content type of the document.
+            Recommended to pass it otherwise auto-detected.
+        :param document_id: the id of the document.
+        :param attributes: Additional attributes to add to the document.
+        :param config: Configuration for the document parsing.
+        :param authorized_groups: The groups that are authorized to access the
+            document. These groups should exist in RBAC. None passed will make the
+            document public.
+        :param merge_groups_on_conflict: Allows combining authorized group field
+          when document already exists, and Document Level Security is enabled.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            UploadDocumentsResult object containing the result of the upload
 
         """
-        if filebytes is not None and file_data_uuid is not None:
-            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`, not both.")
-        if filebytes is None and file_data_uuid is None:
-            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`.")
-
-        if filebytes is not None:
-            b64 = base64.b64encode(filebytes).decode("utf-8")
-            doc = ParseableDocument(
-                id=document_id,
-                filename=filename,
-                content_type=content_type,
-                content_length_bytes=len(filebytes),
-                content_encoded_bytes=b64,
-                attributes=attributes,
-                config=config,
-            )
-        else:
-            doc = ParseableDocument(
-                id=document_id,
-                filename=filename,
-                content_type=content_type,
-                file_data_uuid=file_data_uuid,
-                attributes=attributes,
-                config=config,
-            )
+        doc = ParseableDocument(
+            id=document_id,
+            filename=filename,
+            content_type=content_type,
+            content_length_bytes=content_length_bytes,
+            file_data_uuid=file_data_uuid,
+            attributes=attributes,
+            config=config,
+        )
 
         result = await self._send_request(
             api_name="upload_documents",
@@ -706,8 +755,8 @@ class CompassAsyncClient:
 
         Returns a presigned URL that can be used to PUT raw file bytes directly to
         storage, plus a ``file_data_uuid`` that can later be passed to
-        ``upload_document`` (via the ``file_data_uuid`` parameter) to ingest the
-        uploaded file without re-sending its bytes through the API.
+        ``upload_document_via_uuid`` to ingest the uploaded file without
+        re-sending its bytes through the API.
 
         :param index_name: The name of the index the file will be uploaded to.
         :param filename: The filename of the document to be uploaded.

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -1403,6 +1403,60 @@ class CompassAsyncClient:
 
         return result.result, result.content_type  # type: ignore
 
+    async def get_media_clip(
+        self,
+        *,
+        index_name: str,
+        document_id: str,
+        asset_id: str,
+        start_time: float,
+        end_time: float,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> tuple[str | bytes | dict[str, Any], str]:
+        """
+        Get an audio or video clip from a document asset in Compass.
+
+        Extracts a segment of an audio or video asset between ``start_time`` and
+        ``end_time`` (in seconds). The asset must be of type AUDIO (returns WAV)
+        or VIDEO (returns MP4). The server caps the segment duration at 15 minutes.
+
+        :param index_name: the name of the index
+        :param document_id: the id of the document
+        :param asset_id: the id of the asset
+        :param start_time: start time in seconds for the clip
+        :param end_time: end time in seconds for the clip
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A tuple of the clip bytes and the content type string (e.g.
+            ``"audio/wav"`` or ``"video/mp4"``).
+
+        Raises:
+            CompassError: if the clip cannot be retrieved, either because the asset
+                doesn't exist, is not an audio/video asset, or the user doesn't have
+                permission to access it.
+
+        """
+        result = await self._send_request(
+            api_name="get_visual_element",
+            index_name=index_name,
+            document_id=document_id,
+            asset_id=asset_id,
+            query_params={"start_time": start_time, "end_time": end_time},
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+
+        return result.result, result.content_type  # type: ignore
+
     async def _send_http_request(
         self,
         http_method: str,
@@ -1453,15 +1507,12 @@ class CompassAsyncClient:
 
         content_type = response.headers.get("content-type")
         if content_type in ("image/jpeg", "image/png", "image/webp"):
-            # To handle response from get_document_asset() when the asset
-            # is an image.
             result = response.content
         elif content_type == "text/markdown":
-            # To handle response from get_document_asset() when the asset
-            # is a markdown.
             result = response.text
+        elif content_type is not None and (content_type.startswith("audio/") or content_type.startswith("video/")):
+            result = response.content
         else:
-            # To handle response from other APIs.
             result = response.json() if response.text else None
         return _SendRequestResult(
             result=result,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -673,7 +673,6 @@ class CompassAsyncClient:
         index_name: str,
         filename: str,
         file_data_uuid: uuid.UUID,
-        content_length_bytes: int,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -694,7 +693,6 @@ class CompassAsyncClient:
         :param index_name: the name of the index
         :param filename: the filename of the document
         :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
-        :param content_length_bytes: The size of the uploaded file in bytes.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
         :param document_id: the id of the document.
@@ -720,7 +718,6 @@ class CompassAsyncClient:
             id=document_id,
             filename=filename,
             content_type=content_type,
-            content_length_bytes=content_length_bytes,
             file_data_uuid=file_data_uuid,
             attributes=attributes,
             config=config,
@@ -746,6 +743,7 @@ class CompassAsyncClient:
         *,
         index_name: str,
         content_type: ContentTypeEnum,
+        filename: str,
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
@@ -777,6 +775,7 @@ class CompassAsyncClient:
             index_name=index_name,
             data=UploadFilePresignedUrlRequest(
                 content_type=content_type,
+                filename=filename,
             ),
             max_retries=max_retries,
             retry_wait=retry_wait,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -631,7 +631,7 @@ class CompassAsyncClient:
         :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
-        :param document_id: the id of the document (optional)
+        :param document_id: the id of the document.
         :param attributes: Additional attributes to add to the document.
         :param config: Configuration for the document parsing.
         :param authorized_groups: The groups that are authorized to access the
@@ -672,13 +672,12 @@ class CompassAsyncClient:
                 config=config,
             )
         else:
-            if content_length_bytes is None:
-                raise ValueError("`content_length_bytes` is required when using `file_data_uuid`.")
             doc = ParseableDocument(
                 id=document_id,
                 filename=filename,
                 content_type=content_type,
-                content_length_bytes=content_length_bytes,
+                # This is calculated by the client when file_uuid is provided.
+                content_length_bytes=content_length_bytes or 0,
                 file_data_uuid=file_data_uuid,
                 attributes=attributes,
                 config=config,
@@ -703,7 +702,6 @@ class CompassAsyncClient:
         self,
         *,
         index_name: str,
-        filename: str,
         content_type: ContentTypeEnum,
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
@@ -735,7 +733,6 @@ class CompassAsyncClient:
             api_name="get_upload_presigned_url",
             index_name=index_name,
             data=UploadFilePresignedUrlRequest(
-                filename=filename,
                 content_type=content_type,
             ),
             max_retries=max_retries,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -631,7 +631,7 @@ class CompassAsyncClient:
         :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
-        :param document_id: the id of the document
+        :param document_id: the id of the document (optional)
         :param attributes: Additional attributes to add to the document.
         :param config: Configuration for the document parsing.
         :param authorized_groups: The groups that are authorized to access the

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -603,7 +603,6 @@ class CompassAsyncClient:
         filename: str,
         filebytes: bytes | None = None,
         file_data_uuid: uuid.UUID | None = None,
-        content_length_bytes: int | None = None,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -621,14 +620,12 @@ class CompassAsyncClient:
 
         - **filebytes**: the raw document bytes (will be base64-encoded and sent inline).
         - **file_data_uuid**: a UUID returned by ``get_upload_presigned_url`` after
-          the client has already PUT the file bytes to object storage. When using this
-          path, ``content_length_bytes`` must also be supplied.
+          the client has already PUT the file bytes to object storage.
 
         :param index_name: the name of the index
         :param filename: the filename of the document
         :param filebytes: the bytes of the document
         :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
-        :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
         :param document_id: the id of the document.
@@ -651,8 +648,7 @@ class CompassAsyncClient:
 
         Raises:
             ValueError: If both or neither of ``filebytes`` and ``file_data_uuid``
-                are provided, or if ``content_length_bytes`` is missing when using
-                ``file_data_uuid``.
+                are provided
 
         """
         if filebytes is not None and file_data_uuid is not None:
@@ -676,8 +672,6 @@ class CompassAsyncClient:
                 id=document_id,
                 filename=filename,
                 content_type=content_type,
-                # This is calculated by the client when file_uuid is provided.
-                content_length_bytes=content_length_bytes or 0,
                 file_data_uuid=file_data_uuid,
                 attributes=attributes,
                 config=config,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -1391,7 +1391,7 @@ class CompassAsyncClient:
 
         """
         result = await self._send_request(
-            api_name="get_visual_element",
+            api_name="get_document_asset",
             index_name=index_name,
             document_id=document_id,
             asset_id=asset_id,
@@ -1445,7 +1445,7 @@ class CompassAsyncClient:
 
         """
         result = await self._send_request(
-            api_name="get_visual_element",
+            api_name="get_document_asset",
             index_name=index_name,
             document_id=document_id,
             asset_id=asset_id,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -77,6 +77,8 @@ from cohere_compass.models.documents import (
     PutDocumentsResponse,
     UploadDocumentsResult,
     UploadDocumentsStatus,
+    UploadFilePresignedUrlRequest,
+    UploadFilePresignedUrlResponse,
 )
 from cohere_compass.models.indexes import IndexDetails, ListIndexesResponse, RetentionPolicy
 from cohere_compass.models.search import GetDocumentResponse, RetrievedDocument, SortBy
@@ -588,7 +590,9 @@ class CompassAsyncClient:
         *,
         index_name: str,
         filename: str,
-        filebytes: bytes,
+        filebytes: bytes | None = None,
+        file_data_uuid: uuid.UUID | None = None,
+        content_length_bytes: int | None = None,
         document_id: str,
         attributes: DocumentAttributes = DocumentAttributes(),
         config: ParseableDocumentConfig = ParseableDocumentConfig(),
@@ -602,12 +606,21 @@ class CompassAsyncClient:
         """
         Parse and insert a document into an index in Compass.
 
+        Provide exactly one of ``filebytes`` or ``file_data_uuid``:
+
+        - **filebytes**: the raw document bytes (will be base64-encoded and sent inline).
+        - **file_data_uuid**: a UUID returned by ``get_upload_presigned_url`` after
+          the client has already PUT the file bytes to object storage. When using this
+          path, ``content_length_bytes`` must also be supplied.
+
         :param index_name: the name of the index
         :param filename: the filename of the document
         :param filebytes: the bytes of the document
+        :param file_data_uuid: UUID from a prior ``get_upload_presigned_url`` call.
+        :param content_length_bytes: Required when using ``file_data_uuid``.
         :param content_type: optional content type of the document.
             Recommended to pass it otherwise auto-detected.
-        :param document_id: the id of the document (optional)
+        :param document_id: the id of the document
         :param attributes: Additional attributes to add to the document.
         :param config: Configuration for the document parsing.
         :param authorized_groups: The groups that are authorized to access the
@@ -625,17 +638,40 @@ class CompassAsyncClient:
         Returns:
             UploadDocumentsResult object containing the result of the upload
 
+        Raises:
+            ValueError: If both or neither of ``filebytes`` and ``file_data_uuid``
+                are provided, or if ``content_length_bytes`` is missing when using
+                ``file_data_uuid``.
+
         """
-        b64 = base64.b64encode(filebytes).decode("utf-8")
-        doc = ParseableDocument(
-            id=document_id,
-            filename=filename,
-            content_type=content_type,
-            content_length_bytes=len(filebytes),
-            content_encoded_bytes=b64,
-            attributes=attributes,
-            config=config,
-        )
+        if filebytes is not None and file_data_uuid is not None:
+            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`, not both.")
+        if filebytes is None and file_data_uuid is None:
+            raise ValueError("Provide exactly one of `filebytes` or `file_data_uuid`.")
+
+        if filebytes is not None:
+            b64 = base64.b64encode(filebytes).decode("utf-8")
+            doc = ParseableDocument(
+                id=document_id,
+                filename=filename,
+                content_type=content_type,
+                content_length_bytes=len(filebytes),
+                content_encoded_bytes=b64,
+                attributes=attributes,
+                config=config,
+            )
+        else:
+            if content_length_bytes is None:
+                raise ValueError("`content_length_bytes` is required when using `file_data_uuid`.")
+            doc = ParseableDocument(
+                id=document_id,
+                filename=filename,
+                content_type=content_type,
+                content_length_bytes=content_length_bytes,
+                file_data_uuid=file_data_uuid,
+                attributes=attributes,
+                config=config,
+            )
 
         result = await self._send_request(
             api_name="upload_documents",
@@ -651,6 +687,51 @@ class CompassAsyncClient:
         )
 
         return UploadDocumentsResult.model_validate(result.result)
+
+    async def get_upload_presigned_url(
+        self,
+        *,
+        index_name: str,
+        filename: str,
+        content_type: ContentTypeEnum,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> UploadFilePresignedUrlResponse:
+        """
+        Get a presigned URL to upload a file directly to object storage.
+
+        Returns a presigned URL that can be used to PUT raw file bytes directly to
+        storage, plus a ``file_data_uuid`` that can later be passed to
+        ``upload_document`` (via the ``file_data_uuid`` parameter) to ingest the
+        uploaded file without re-sending its bytes through the API.
+
+        :param index_name: The name of the index the file will be uploaded to.
+        :param filename: The filename of the document to be uploaded.
+        :param content_type: The content type (MIME type) of the document. The client
+            must send the same value as the Content-Type header when PUTting bytes to
+            the returned presigned URL.
+        :param max_retries: Maximum number of retries for failed requests.
+        :param retry_wait: Time to wait between retries.
+        :param timeout: Request timeout duration.
+
+        Returns:
+            UploadFilePresignedUrlResponse containing the presigned URL, file_data_uuid,
+            expiration, and content type.
+
+        """
+        result = await self._send_request(
+            api_name="get_upload_presigned_url",
+            index_name=index_name,
+            data=UploadFilePresignedUrlRequest(
+                filename=filename,
+                content_type=content_type,
+            ),
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return UploadFilePresignedUrlResponse.model_validate(result.result)
 
     async def upload_document_status(
         self,

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -284,7 +284,7 @@ class ParseableDocument(BaseModel):
     id: str
     filename: Annotated[str, StringConstraints(min_length=1)]  # Ensures the filename is a non-empty string
     content_type: str | None = None
-    content_length_bytes: PositiveInt  # File size must be a non-negative integer
+    content_length_bytes: PositiveInt | None = None  # File size must be a non-negative integer
     content_encoded_bytes: str | None = None  # Base64 encoded bytes of the file
     file_data_uuid: UUID4 | None = None
     attributes: DocumentAttributes

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -285,9 +285,18 @@ class ParseableDocument(BaseModel):
     filename: Annotated[str, StringConstraints(min_length=1)]  # Ensures the filename is a non-empty string
     content_type: str | None = None
     content_length_bytes: PositiveInt  # File size must be a non-negative integer
-    content_encoded_bytes: str  # Base64-encoded file contents
+    content_encoded_bytes: str | None = None  # Base64 encoded bytes of the file
+    file_data_uuid: UUID4 | None = None
     attributes: DocumentAttributes
     config: ParseableDocumentConfig = ParseableDocumentConfig()
+
+    @model_validator(mode="after")
+    def _validate_content_source(self) -> "ParseableDocument":
+        has_bytes = self.content_encoded_bytes is not None
+        has_uuid = self.file_data_uuid is not None
+        if has_bytes == has_uuid:
+            raise ValueError("Exactly one of `content_encoded_bytes` or `file_data_uuid` must be provided.")
+        return self
 
 
 class UploadDocumentsInput(BaseModel):
@@ -381,10 +390,23 @@ class ParsedDocumentResponse(BaseModel):
 
 
 class AssetPresignedUrlRequest(BaseModel):
-    """A single asset presigned URL request item."""
+    """
+    A single asset presigned URL request item.
+
+    The document_id is the ID of the document.
+    The asset_id is the ID of the asset in the asset_info.
+    The x0, y0, x1, y1 are the coordinates of the asset if you want cropped images.
+    The start_time and end_time are the start and end times of media assets like audio or video.
+    """
 
     document_id: str
     asset_id: uuid.UUID
+    x0: int | None = Field(default=None, ge=0, le=1000)
+    y0: int | None = Field(default=None, ge=0, le=1000)
+    x1: int | None = Field(default=None, ge=0, le=1000)
+    y1: int | None = Field(default=None, ge=0, le=1000)
+    start_time: float | None = Field(default=None, ge=0)
+    end_time: float | None = Field(default=None, ge=0)
 
 
 class GetAssetPresignedUrlsRequest(BaseModel):
@@ -398,7 +420,7 @@ class AssetPresignedUrlDetails(BaseModel):
 
     document_id: str
     asset_id: uuid.UUID
-    presigned_url: str
+    presigned_url: str | None
 
 
 class GetAssetPresignedUrlsResponse(BaseModel):
@@ -463,3 +485,19 @@ class ContentTypeEnum(str, Enum):
 
     # Message types
     MessageRfc822 = "message/rfc822"  # eml files
+
+
+class UploadFilePresignedUrlRequest(BaseModel):
+    """Request body for getting a presigned URL to upload a file directly to storage."""
+
+    filename: Annotated[str, StringConstraints(min_length=1)]
+    content_type: ContentTypeEnum
+
+
+class UploadFilePresignedUrlResponse(BaseModel):
+    """Response from the presigned URL upload endpoint."""
+
+    file_data_uuid: UUID4
+    presigned_url: str
+    expires_in_seconds: int
+    content_type: str

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -490,7 +490,6 @@ class ContentTypeEnum(str, Enum):
 class UploadFilePresignedUrlRequest(BaseModel):
     """Request body for getting a presigned URL to upload a file directly to storage."""
 
-    filename: Annotated[str, StringConstraints(min_length=1)]
     content_type: ContentTypeEnum
 
 
@@ -500,4 +499,3 @@ class UploadFilePresignedUrlResponse(BaseModel):
     file_data_uuid: UUID4
     presigned_url: str
     expires_in_seconds: int
-    content_type: str

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -491,6 +491,7 @@ class UploadFilePresignedUrlRequest(BaseModel):
     """Request body for getting a presigned URL to upload a file directly to storage."""
 
     content_type: ContentTypeEnum
+    filename: str
 
 
 class UploadFilePresignedUrlResponse(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.11.1"
+version = "2.12.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -379,6 +379,30 @@ def test_get_document_asset_image(client: CompassClient, respx_mock: MockRouter)
     assert content_type == "image/png"
 
 
+def test_get_media_clip(client: CompassClient, respx_mock: MockRouter):
+    route = respx_mock.get(
+        "http://test.com/v1/indexes/test_index/documents/doc_audio/assets/audio_asset_id",
+        params={"start_time": "1.5", "end_time": "3.0"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            content=b"fake-wav-bytes",
+            headers={"Content-Type": "audio/wav"},
+        ),
+    )
+    clip, content_type = client.get_media_clip(
+        index_name="test_index",
+        document_id="doc_audio",
+        asset_id="audio_asset_id",
+        start_time=1.5,
+        end_time=3.0,
+    )
+    assert route.called
+    assert isinstance(clip, bytes)
+    assert clip == b"fake-wav-bytes"
+    assert content_type == "audio/wav"
+
+
 def test_direct_search_is_valid(client: CompassClient, respx_mock: MockRouter):
     route = respx_mock.post("http://test.com/v1/indexes/test_index/_direct_search").mock(
         return_value=httpx.Response(

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -1154,19 +1154,9 @@ def test_asset_presigned_url_details_with_url():
 
 def test_upload_file_presigned_url_request():
     req = UploadFilePresignedUrlRequest(
-        filename="report.pdf",
         content_type=ContentTypeEnum.ApplicationPdf,
     )
-    assert req.filename == "report.pdf"
     assert req.content_type == ContentTypeEnum.ApplicationPdf
-
-
-def test_upload_file_presigned_url_request_empty_filename():
-    with pytest.raises(ValidationError):
-        UploadFilePresignedUrlRequest(
-            filename="",
-            content_type=ContentTypeEnum.ApplicationPdf,
-        )
 
 
 def test_upload_file_presigned_url_response():
@@ -1175,19 +1165,17 @@ def test_upload_file_presigned_url_response():
         file_data_uuid=test_uuid,
         presigned_url="https://storage.example.com/upload?sig=abc",
         expires_in_seconds=3600,
-        content_type="application/pdf",
     )
     assert resp.file_data_uuid == test_uuid
     assert resp.presigned_url == "https://storage.example.com/upload?sig=abc"
     assert resp.expires_in_seconds == 3600
-    assert resp.content_type == "application/pdf"
 
 
 # ── Client: upload_document with file_data_uuid ──────────────────────────
 
 
 @respx.mock
-def test_upload_document_with_file_data_uuid(client: CompassClient, respx_mock: MockRouter):
+def test_upload_document_via_uuid(client: CompassClient, respx_mock: MockRouter):
     upload_id = uuid.uuid4()
     document_id = "test_document_id"
     file_uuid = uuid.uuid4()
@@ -1196,7 +1184,7 @@ def test_upload_document_with_file_data_uuid(client: CompassClient, respx_mock: 
         return_value=httpx.Response(200, json={"upload_id": str(upload_id), "document_ids": [document_id]})
     )
 
-    result = client.upload_document(
+    result = client.upload_document_via_uuid(
         index_name="test_index",
         filename="test.pdf",
         file_data_uuid=file_uuid,
@@ -1213,40 +1201,6 @@ def test_upload_document_with_file_data_uuid(client: CompassClient, respx_mock: 
     assert doc_payload["file_data_uuid"] == str(file_uuid)
     assert doc_payload.get("content_encoded_bytes") is None
     assert doc_payload["content_length_bytes"] == 4096
-
-
-@respx.mock
-def test_upload_document_rejects_both_filebytes_and_uuid(client: CompassClient, respx_mock: MockRouter):
-    with pytest.raises(ValueError, match="not both"):
-        client.upload_document(
-            index_name="test_index",
-            filename="test.pdf",
-            filebytes=b"test",
-            file_data_uuid=uuid.uuid4(),
-            content_length_bytes=4,
-            document_id="doc1",
-        )
-
-
-@respx.mock
-def test_upload_document_rejects_neither_filebytes_nor_uuid(client: CompassClient, respx_mock: MockRouter):
-    with pytest.raises(ValueError, match="Provide exactly one"):
-        client.upload_document(
-            index_name="test_index",
-            filename="test.pdf",
-            document_id="doc1",
-        )
-
-
-@respx.mock
-def test_upload_document_uuid_requires_content_length(client: CompassClient, respx_mock: MockRouter):
-    with pytest.raises(ValueError, match="content_length_bytes"):
-        client.upload_document(
-            index_name="test_index",
-            filename="test.pdf",
-            file_data_uuid=uuid.uuid4(),
-            document_id="doc1",
-        )
 
 
 # ── Client: get_upload_presigned_url ─────────────────────────────────────
@@ -1269,7 +1223,6 @@ def test_get_upload_presigned_url(client: CompassClient, respx_mock: MockRouter)
 
     result = client.get_upload_presigned_url(
         index_name="test_index",
-        filename="report.pdf",
         content_type=ContentTypeEnum.ApplicationPdf,
     )
 
@@ -1277,10 +1230,8 @@ def test_get_upload_presigned_url(client: CompassClient, respx_mock: MockRouter)
     assert result.file_data_uuid == file_uuid
     assert result.presigned_url == "https://storage.example.com/upload?sig=xyz"
     assert result.expires_in_seconds == 3600
-    assert result.content_type == "application/pdf"
 
     request_body = json.loads(route.calls.last.request.content)
-    assert request_body["filename"] == "report.pdf"
     assert request_body["content_type"] == "application/pdf"
 
 

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -1258,6 +1258,8 @@ def test_get_upload_presigned_url(client: CompassClient, respx_mock: MockRouter)
     request_body = json.loads(route.calls.last.request.content)
     assert request_body["filename"] == "report.pdf"
     assert request_body["content_type"] == "application/pdf"
+
+
 # Retention policy tests
 
 

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -23,11 +23,16 @@ from cohere_compass.models import (
 )
 from cohere_compass.models.config import IndexConfig
 from cohere_compass.models.documents import (
+    AssetPresignedUrlDetails,
+    AssetPresignedUrlRequest,
     AssetType,
     CompassDocumentMetadata,
     ContentTypeEnum,
     DocumentAttributes,
+    ParseableDocument,
     UploadDocumentsResult,
+    UploadFilePresignedUrlRequest,
+    UploadFilePresignedUrlResponse,
 )
 from cohere_compass.models.indexes import IndexDetails, IndexInfo
 from cohere_compass.models.search import (
@@ -982,3 +987,269 @@ def test_get_asset_presigned_urls_success(client: CompassClient, respx_mock: Moc
     assert result[1].document_id == "doc_456"
     assert result[1].asset_id == asset_b_uuid
     assert result[1].presigned_url == "https://example.com/asset_B?X-Amz-Signature=..."
+
+
+# ── ParseableDocument model validator tests ──────────────────────────────
+
+
+def test_parseable_document_with_encoded_bytes():
+    doc = ParseableDocument(
+        id="doc1",
+        filename="test.pdf",
+        content_length_bytes=100,
+        content_encoded_bytes="dGVzdA==",
+        attributes=DocumentAttributes(),
+    )
+    assert doc.content_encoded_bytes == "dGVzdA=="
+    assert doc.file_data_uuid is None
+
+
+def test_parseable_document_with_file_data_uuid():
+    test_uuid = uuid.uuid4()
+    doc = ParseableDocument(
+        id="doc1",
+        filename="test.pdf",
+        content_length_bytes=100,
+        file_data_uuid=test_uuid,
+        attributes=DocumentAttributes(),
+    )
+    assert doc.file_data_uuid == test_uuid
+    assert doc.content_encoded_bytes is None
+
+
+def test_parseable_document_rejects_both_bytes_and_uuid():
+    with pytest.raises(ValidationError, match="Exactly one of"):
+        ParseableDocument(
+            id="doc1",
+            filename="test.pdf",
+            content_length_bytes=100,
+            content_encoded_bytes="dGVzdA==",
+            file_data_uuid=uuid.uuid4(),
+            attributes=DocumentAttributes(),
+        )
+
+
+def test_parseable_document_rejects_neither_bytes_nor_uuid():
+    with pytest.raises(ValidationError, match="Exactly one of"):
+        ParseableDocument(
+            id="doc1",
+            filename="test.pdf",
+            content_length_bytes=100,
+            attributes=DocumentAttributes(),
+        )
+
+
+# ── AssetPresignedUrlRequest new optional fields ─────────────────────────
+
+
+def test_asset_presigned_url_request_with_crop_fields():
+    asset_id = uuid.uuid4()
+    req = AssetPresignedUrlRequest(
+        document_id="doc1",
+        asset_id=asset_id,
+        x0=10,
+        y0=20,
+        x1=500,
+        y1=800,
+    )
+    assert req.x0 == 10
+    assert req.y0 == 20
+    assert req.x1 == 500
+    assert req.y1 == 800
+    assert req.start_time is None
+    assert req.end_time is None
+
+
+def test_asset_presigned_url_request_with_time_fields():
+    asset_id = uuid.uuid4()
+    req = AssetPresignedUrlRequest(
+        document_id="doc1",
+        asset_id=asset_id,
+        start_time=1.5,
+        end_time=10.0,
+    )
+    assert req.start_time == 1.5
+    assert req.end_time == 10.0
+    assert req.x0 is None
+
+
+def test_asset_presigned_url_request_defaults_none():
+    asset_id = uuid.uuid4()
+    req = AssetPresignedUrlRequest(document_id="doc1", asset_id=asset_id)
+    assert req.x0 is None
+    assert req.y0 is None
+    assert req.x1 is None
+    assert req.y1 is None
+    assert req.start_time is None
+    assert req.end_time is None
+
+
+def test_asset_presigned_url_request_crop_bounds_validation():
+    with pytest.raises(ValidationError):
+        AssetPresignedUrlRequest(
+            document_id="doc1",
+            asset_id=uuid.uuid4(),
+            x0=1001,
+        )
+    with pytest.raises(ValidationError):
+        AssetPresignedUrlRequest(
+            document_id="doc1",
+            asset_id=uuid.uuid4(),
+            start_time=-1.0,
+        )
+
+
+# ── AssetPresignedUrlDetails nullable presigned_url ──────────────────────
+
+
+def test_asset_presigned_url_details_null_url():
+    detail = AssetPresignedUrlDetails(
+        document_id="doc1",
+        asset_id=uuid.uuid4(),
+        presigned_url=None,
+    )
+    assert detail.presigned_url is None
+
+
+def test_asset_presigned_url_details_with_url():
+    detail = AssetPresignedUrlDetails(
+        document_id="doc1",
+        asset_id=uuid.uuid4(),
+        presigned_url="https://example.com/asset",
+    )
+    assert detail.presigned_url == "https://example.com/asset"
+
+
+# ── UploadFilePresignedUrl models ────────────────────────────────────────
+
+
+def test_upload_file_presigned_url_request():
+    req = UploadFilePresignedUrlRequest(
+        filename="report.pdf",
+        content_type=ContentTypeEnum.ApplicationPdf,
+    )
+    assert req.filename == "report.pdf"
+    assert req.content_type == ContentTypeEnum.ApplicationPdf
+
+
+def test_upload_file_presigned_url_request_empty_filename():
+    with pytest.raises(ValidationError):
+        UploadFilePresignedUrlRequest(
+            filename="",
+            content_type=ContentTypeEnum.ApplicationPdf,
+        )
+
+
+def test_upload_file_presigned_url_response():
+    test_uuid = uuid.uuid4()
+    resp = UploadFilePresignedUrlResponse(
+        file_data_uuid=test_uuid,
+        presigned_url="https://storage.example.com/upload?sig=abc",
+        expires_in_seconds=3600,
+        content_type="application/pdf",
+    )
+    assert resp.file_data_uuid == test_uuid
+    assert resp.presigned_url == "https://storage.example.com/upload?sig=abc"
+    assert resp.expires_in_seconds == 3600
+    assert resp.content_type == "application/pdf"
+
+
+# ── Client: upload_document with file_data_uuid ──────────────────────────
+
+
+@respx.mock
+def test_upload_document_with_file_data_uuid(client: CompassClient, respx_mock: MockRouter):
+    upload_id = uuid.uuid4()
+    document_id = "test_document_id"
+    file_uuid = uuid.uuid4()
+
+    route = respx_mock.post("http://test.com/v1/indexes/test_index/documents/upload").mock(
+        return_value=httpx.Response(200, json={"upload_id": str(upload_id), "document_ids": [document_id]})
+    )
+
+    result = client.upload_document(
+        index_name="test_index",
+        filename="test.pdf",
+        file_data_uuid=file_uuid,
+        content_length_bytes=4096,
+        content_type=ContentTypeEnum.ApplicationPdf,
+        document_id=document_id,
+    )
+
+    assert route.called
+    assert result == UploadDocumentsResult(upload_id=upload_id, document_ids=[document_id])
+
+    request_body = json.loads(route.calls.last.request.content)
+    doc_payload = request_body["documents"][0]
+    assert doc_payload["file_data_uuid"] == str(file_uuid)
+    assert doc_payload.get("content_encoded_bytes") is None
+    assert doc_payload["content_length_bytes"] == 4096
+
+
+@respx.mock
+def test_upload_document_rejects_both_filebytes_and_uuid(client: CompassClient, respx_mock: MockRouter):
+    with pytest.raises(ValueError, match="not both"):
+        client.upload_document(
+            index_name="test_index",
+            filename="test.pdf",
+            filebytes=b"test",
+            file_data_uuid=uuid.uuid4(),
+            content_length_bytes=4,
+            document_id="doc1",
+        )
+
+
+@respx.mock
+def test_upload_document_rejects_neither_filebytes_nor_uuid(client: CompassClient, respx_mock: MockRouter):
+    with pytest.raises(ValueError, match="Provide exactly one"):
+        client.upload_document(
+            index_name="test_index",
+            filename="test.pdf",
+            document_id="doc1",
+        )
+
+
+@respx.mock
+def test_upload_document_uuid_requires_content_length(client: CompassClient, respx_mock: MockRouter):
+    with pytest.raises(ValueError, match="content_length_bytes"):
+        client.upload_document(
+            index_name="test_index",
+            filename="test.pdf",
+            file_data_uuid=uuid.uuid4(),
+            document_id="doc1",
+        )
+
+
+# ── Client: get_upload_presigned_url ─────────────────────────────────────
+
+
+@respx.mock
+def test_get_upload_presigned_url(client: CompassClient, respx_mock: MockRouter):
+    file_uuid = uuid.uuid4()
+    route = respx_mock.post("http://test.com/v1/indexes/test_index/documents/upload/presigned_url").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "file_data_uuid": str(file_uuid),
+                "presigned_url": "https://storage.example.com/upload?sig=xyz",
+                "expires_in_seconds": 3600,
+                "content_type": "application/pdf",
+            },
+        )
+    )
+
+    result = client.get_upload_presigned_url(
+        index_name="test_index",
+        filename="report.pdf",
+        content_type=ContentTypeEnum.ApplicationPdf,
+    )
+
+    assert route.called
+    assert result.file_data_uuid == file_uuid
+    assert result.presigned_url == "https://storage.example.com/upload?sig=xyz"
+    assert result.expires_in_seconds == 3600
+    assert result.content_type == "application/pdf"
+
+    request_body = json.loads(route.calls.last.request.content)
+    assert request_body["filename"] == "report.pdf"
+    assert request_body["content_type"] == "application/pdf"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -1155,6 +1155,7 @@ def test_asset_presigned_url_details_with_url():
 def test_upload_file_presigned_url_request():
     req = UploadFilePresignedUrlRequest(
         content_type=ContentTypeEnum.ApplicationPdf,
+        filename="test.pdf",
     )
     assert req.content_type == ContentTypeEnum.ApplicationPdf
 
@@ -1188,7 +1189,6 @@ def test_upload_document_via_uuid(client: CompassClient, respx_mock: MockRouter)
         index_name="test_index",
         filename="test.pdf",
         file_data_uuid=file_uuid,
-        content_length_bytes=4096,
         content_type=ContentTypeEnum.ApplicationPdf,
         document_id=document_id,
     )
@@ -1200,7 +1200,6 @@ def test_upload_document_via_uuid(client: CompassClient, respx_mock: MockRouter)
     doc_payload = request_body["documents"][0]
     assert doc_payload["file_data_uuid"] == str(file_uuid)
     assert doc_payload.get("content_encoded_bytes") is None
-    assert doc_payload["content_length_bytes"] == 4096
 
 
 # ── Client: get_upload_presigned_url ─────────────────────────────────────
@@ -1224,6 +1223,7 @@ def test_get_upload_presigned_url(client: CompassClient, respx_mock: MockRouter)
     result = client.get_upload_presigned_url(
         index_name="test_index",
         content_type=ContentTypeEnum.ApplicationPdf,
+        filename="test.pdf",
     )
 
     assert route.called


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces new functionality for uploading documents to Compass, allowing users to upload files directly to object storage and ingest them without re-sending bytes through the API.

**Changes:**
- **New API Endpoints**:
  - Added `get_upload_presigned_url` to generate a presigned URL for direct file uploads to object storage.
  - Updated `upload_document` to accept either `filebytes` or `file_data_uuid` for document ingestion.
- **Model Updates**:
  - Introduced `UploadFilePresignedUrlRequest` and `UploadFilePresignedUrlResponse` models for handling presigned URL requests and responses.
  - Enhanced `ParseableDocument` to support `file_data_uuid` and validate that either `content_encoded_bytes` or `file_data_uuid` is provided.
- **Client Functionality**:
  - Implemented `get_upload_presigned_url` in both sync and async clients to fetch presigned URLs.
  - Updated `upload_document` in both clients to handle `file_data_uuid` and enforce validation rules.
- **Testing**:
  - Added tests for new models, client methods, and validation scenarios.

<!-- end-generated-description -->