### PR TITLE
feat: add SubTables tabular parsing strategy

### DIFF
--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -36,10 +36,12 @@ class TabularParsingStrategy(str, Enum):
 
     Granular: Convert each row of the table to a document chunk.
     Digest: Creates one chunk for the table, containing metadata about the table.
+    SubTables: Splits the table into semantic sub-table chunks optimized for retrieval.
     """
 
     Granular = "granular"
     Digest = "digest"
+    SubTables = "subtables"
 
     @classmethod
     def _missing_(cls, value: Any):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.12.4"
+version = "2.12.5"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Add TabularParsingStrategy.SubTables so clients can request the semantic sub-table chunking strategy for CSV/Excel/ODS files.

Needs: https://github.com/cohere-ai/compass/pull/2717