### PR TITLE
fix: Reverting presigned url to str, to keep it backward compatible

### DIFF
--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Literal
 
 # 3rd party imports
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from cohere_compass.models.documents import AssetType
 
@@ -26,8 +26,13 @@ class AssetInfo(BaseModel):
     asset_id: str | None = None
     asset_type: AssetType
     content_type: str
-    presigned_url: str | None = None
+    presigned_url: str
     visual_elements: list[VisualElement] | None = None
+
+    @field_validator("presigned_url", mode="before")
+    @classmethod
+    def _default_presigned_url(cls, value: str | None) -> str:
+        return value if value is not None else ""
 
 
 class RetrievedChunk(BaseModel):

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -2,10 +2,10 @@
 
 # Python imports
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 # 3rd party imports
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, model_validator
 
 from cohere_compass.models.documents import AssetType
 
@@ -29,10 +29,20 @@ class AssetInfo(BaseModel):
     presigned_url: str
     visual_elements: list[VisualElement] | None = None
 
-    @field_validator("presigned_url", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def _default_presigned_url(cls, value: str | None) -> str:
-        return value if value is not None else ""
+    def _default_presigned_url(cls, data: Any) -> Any:
+        """
+        Ensure that the presigned_url is always present.
+
+        This is done to keep it backward compatible.
+        """
+        if isinstance(data, dict):
+            values = cast(dict[str, Any], data)
+            if values.get("presigned_url") is None:
+                values = {**values, "presigned_url": ""}
+            return values
+        return data
 
 
 class RetrievedChunk(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.12.1"
+version = "2.12.2"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -41,6 +41,7 @@ from cohere_compass.models.indexes import (
     RetentionType,
 )
 from cohere_compass.models.search import (
+    AssetInfo,
     SortBy,
 )
 from tests.utils import SyncifiedCompassAsyncClient
@@ -1147,6 +1148,41 @@ def test_asset_presigned_url_details_with_url():
         presigned_url="https://example.com/asset",
     )
     assert detail.presigned_url == "https://example.com/asset"
+
+
+# ── AssetInfo presigned_url null handling ────────────────────────────────
+
+
+def test_asset_info_null_presigned_url_defaults_to_empty_string():
+    asset = AssetInfo.model_validate(
+        {
+            "asset_type": AssetType.PAGE_IMAGE,
+            "content_type": "image/png",
+            "presigned_url": None,
+        }
+    )
+    assert asset.presigned_url == ""
+
+
+def test_asset_info_missing_presigned_url_defaults_to_empty_string():
+    asset = AssetInfo.model_validate(
+        {
+            "asset_type": AssetType.PAGE_IMAGE,
+            "content_type": "image/png",
+        }
+    )
+    assert asset.presigned_url == ""
+
+
+def test_asset_info_with_presigned_url():
+    asset = AssetInfo.model_validate(
+        {
+            "asset_type": AssetType.PAGE_IMAGE,
+            "content_type": "image/png",
+            "presigned_url": "https://example.com/asset",
+        }
+    )
+    assert asset.presigned_url == "https://example.com/asset"
 
 
 # ── UploadFilePresignedUrl models ────────────────────────────────────────


### PR DESCRIPTION
Reverting presigned url from str | None to str = "". To keep it backward compatible 