### PR TITLE
fix: Adding NEQ filter type in sdk

### DIFF
--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -114,6 +114,7 @@ class SearchFilter(BaseModel):
         """Types of filters supported."""
 
         EQ = "$eq"
+        NEQ = "$neq"
         LT_EQ = "$lte"
         GT_EQ = "$gte"
         WORD_MATCH = "$wordMatch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.12.2"
+version = "2.12.3"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -936,6 +936,45 @@ def test_search_documents_with_filters(client: CompassClient, respx_mock: MockRo
     assert result.hits[0].document_id == "doc1"
 
 
+@respx.mock
+def test_search_documents_with_neq_filter(client: CompassClient, respx_mock: MockRouter):
+    route = respx_mock.post("http://test.com/v1/indexes/test_index/documents/_search").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "hits": [
+                    {
+                        "document_id": "doc1",
+                        "score": 0.9,
+                        "content": {"department": "sales"},
+                        "path": "doc1.pdf",
+                        "parent_document_id": "parent1",
+                        "chunks": [],
+                    }
+                ]
+            },
+        )
+    )
+
+    search_filter = SearchFilter(field="department", type=SearchFilter.FilterType.NEQ, value="engineering")
+    result = client.search_documents(index_name="test_index", query="test query", top_k=10, filters=[search_filter])
+
+    assert route.called
+    payload = json.loads(route.calls.last.request.content)
+    assert payload["filters"] == [{"field": "department", "type": "$neq", "value": "engineering"}]
+    assert result.hits[0].document_id == "doc1"
+
+
+def test_search_filter_neq_serialization():
+    search_filter = SearchFilter(field="department", type=SearchFilter.FilterType.NEQ, value="engineering")
+
+    assert search_filter.model_dump(mode="json") == {
+        "field": "department",
+        "type": "$neq",
+        "value": "engineering",
+    }
+
+
 # Test edge cases and validation
 @respx.mock
 def test_empty_query_search(client: CompassClient, respx_mock: MockRouter):


### PR DESCRIPTION
[Linked issue](https://github.com/cohere-ai/cohere-compass-sdk/issues/211)

<!-- begin-generated-description -->

## Description
This PR introduces a new filter type, `NEQ`, to the `FilterType` enum in the `cohere_compass/models/search.py` file. This addition allows for filtering documents based on values that are not equal to a specified value.

## Changes
- **New Filter Type**: Added `NEQ = "$neq"` to the `FilterType` enum, enabling inequality filtering.
- **Test for `NEQ` Filter**: Introduced `test_search_documents_with_neq_filter` in `tests/test_compass_client.py` to verify the functionality of the new filter type.
- **Serialization Test**: Added `test_search_filter_neq_serialization` to ensure correct JSON serialization of the `NEQ` filter.

<!-- end-generated-description -->