### PR TITLE
feat: add synchronizer API

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -87,6 +87,17 @@ from cohere_compass.models.search import (
     RetrievedDocument,
     SortBy,
 )
+from cohere_compass.models.synchronizers import (
+    DataOriginResponse,
+    GetLatestSyncJobResponse,
+    GetSyncStatusResponse,
+    ListSynchronizerResponse,
+    OAuthResponse,
+    SynchronizerResponse,
+    TreeRequest,
+    TreeResponse,
+    UpsertSynchronizerRequest,
+)
 from cohere_compass.utils.documents import partition_documents
 from cohere_compass.utils.retry import is_retryable_httpx_exception
 
@@ -223,7 +234,54 @@ API_DEFINITIONS = {
         "DELETE",
         "indexes/{index_name}/retention",
     ),
+    # Synchronizer APIs
+    "list_data_origins": (
+        "GET",
+        "synchronizers/data-origins",
+    ),
+    "upsert_synchronizer": (
+        "PUT",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}",
+    ),
+    "get_synchronizer": (
+        "GET",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}",
+    ),
+    "list_synchronizers": (
+        "GET",
+        "indexes/{index_name}/synchronizers",
+    ),
+    "delete_synchronizer": (
+        "DELETE",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}",
+    ),
+    "get_synchronizer_tree": (
+        "POST",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}/tree",
+    ),
+    "get_synchronizer_oauth_url": (
+        "GET",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}/oauth/auth",
+    ),
+    "start_sync": (
+        "POST",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}/sync",
+    ),
+    "get_sync_status": (
+        "GET",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}/sync",
+    ),
+    "get_latest_sync_job": (
+        "GET",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}/sync/latest-job",
+    ),
+    "cancel_sync": (
+        "POST",
+        "indexes/{index_name}/synchronizers/{synchronizer_name}/cancel",
+    ),
 }
+
+SYNCHRONIZER_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
 
 
 class CompassClient:
@@ -571,6 +629,396 @@ class CompassClient:
             retry_wait=retry_wait,
             timeout=timeout,
         )
+
+    def list_data_origins(
+        self,
+        *,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> DataOriginResponse:
+        """
+        List the data origins supported by this deployment (e.g. SharePoint, OneDrive).
+
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A DataOriginResponse listing the supported data origins.
+
+        """
+        result = self._send_request(
+            api_name="list_data_origins",
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return DataOriginResponse.model_validate(result.result)
+
+    def upsert_synchronizer(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        synchronizer: UpsertSynchronizerRequest,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Create or update a synchronizer on an index.
+
+        On create, this provisions the backing Atlas role, data connection, and data
+        consumer. On update, the credential owner may change the data selector or
+        credential bundle; a non-owner may only replace the credentials with their own.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name. Must match
+            ``^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$``.
+        :param synchronizer: The synchronizer configuration to upsert.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The upserted SynchronizerResponse.
+
+        :raises ValueError: If the synchronizer name contains invalid characters.
+
+        """
+        if not re.match(SYNCHRONIZER_NAME_PATTERN, synchronizer_name):
+            raise ValueError(f"Invalid synchronizer name '{synchronizer_name}', please avoid special characters.")
+        result = self._send_request(
+            api_name="upsert_synchronizer",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            data=synchronizer,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
+
+    def get_synchronizer(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Get a synchronizer and its current authentication status.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The requested SynchronizerResponse.
+
+        """
+        result = self._send_request(
+            api_name="get_synchronizer",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
+
+    def list_synchronizers(
+        self,
+        *,
+        index_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> ListSynchronizerResponse:
+        """
+        List all synchronizers on an index, regardless of which user created them.
+
+        :param index_name: The index to list synchronizers for.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A ListSynchronizerResponse with all synchronizers for the index.
+
+        """
+        result = self._send_request(
+            api_name="list_synchronizers",
+            index_name=index_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return ListSynchronizerResponse.model_validate(result.result)
+
+    def delete_synchronizer(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ):
+        """
+        Delete a synchronizer and clean up its Atlas resources.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        """
+        self._send_request(
+            api_name="delete_synchronizer",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+
+    def get_synchronizer_tree(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        tree_request: TreeRequest | None = None,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> TreeResponse:
+        """
+        Browse the tree structure of a synchronizer's data origin (e.g. folders).
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param tree_request: Which subtree to browse and how. Defaults to the root.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A TreeResponse with the requested tree entries.
+
+        """
+        result = self._send_request(
+            api_name="get_synchronizer_tree",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            data=tree_request or TreeRequest(),
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return TreeResponse.model_validate(result.result)
+
+    def get_synchronizer_oauth_url(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> OAuthResponse:
+        """
+        Get the OAuth authorization URL for a synchronizer's credential.
+
+        The credential owner visits this URL to authorize the data origin before
+        syncing can succeed.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            An OAuthResponse containing the authorization URL.
+
+        """
+        result = self._send_request(
+            api_name="get_synchronizer_oauth_url",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return OAuthResponse.model_validate(result.result)
+
+    def start_sync(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Start a sync job for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The SynchronizerResponse after the sync job has been started.
+
+        """
+        result = self._send_request(
+            api_name="start_sync",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
+
+    def get_sync_status(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> GetSyncStatusResponse:
+        """
+        Get the cumulative sync status for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A GetSyncStatusResponse with the cumulative sync status.
+
+        """
+        result = self._send_request(
+            api_name="get_sync_status",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return GetSyncStatusResponse.model_validate(result.result)
+
+    def get_latest_sync_job(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> GetLatestSyncJobResponse:
+        """
+        Get the latest sync job for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A GetLatestSyncJobResponse with the most recent sync job.
+
+        """
+        result = self._send_request(
+            api_name="get_latest_sync_job",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return GetLatestSyncJobResponse.model_validate(result.result)
+
+    def cancel_sync(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Cancel the current sync job for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The SynchronizerResponse after the sync job has been cancelled.
+
+        """
+        result = self._send_request(
+            api_name="cancel_sync",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
 
     def delete_document(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -9,6 +9,7 @@ concurrent operations and comprehensive error handling.
 # Python imports
 import base64
 import os
+import re
 import uuid
 from collections import deque
 from collections.abc import AsyncIterable, Iterable
@@ -31,6 +32,7 @@ from tenacity import (
 from cohere_compass import GroupAuthorizationInput
 from cohere_compass.clients.compass import (
     API_DEFINITIONS,
+    SYNCHRONIZER_NAME_PATTERN,
     _SendRequestResult,  # pyright: ignore[reportPrivateUsage]
     logger,
 )
@@ -82,10 +84,19 @@ from cohere_compass.models.documents import (
 )
 from cohere_compass.models.indexes import IndexDetails, ListIndexesResponse, RetentionPolicy
 from cohere_compass.models.search import GetDocumentResponse, RetrievedDocument, SortBy
-from cohere_compass.utils.asyn import async_apply, async_enumerate
-from cohere_compass.utils.documents import (
-    partition_documents_async,
+from cohere_compass.models.synchronizers import (
+    DataOriginResponse,
+    GetLatestSyncJobResponse,
+    GetSyncStatusResponse,
+    ListSynchronizerResponse,
+    OAuthResponse,
+    SynchronizerResponse,
+    TreeRequest,
+    TreeResponse,
+    UpsertSynchronizerRequest,
 )
+from cohere_compass.utils.asyn import async_apply, async_enumerate
+from cohere_compass.utils.documents import partition_documents_async
 from cohere_compass.utils.retry import is_retryable_httpx_exception
 
 
@@ -431,6 +442,396 @@ class CompassAsyncClient:
             retry_wait=retry_wait,
             timeout=timeout,
         )
+
+    async def list_data_origins(
+        self,
+        *,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> DataOriginResponse:
+        """
+        List the data origins supported by this deployment (e.g. SharePoint, OneDrive).
+
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A DataOriginResponse listing the supported data origins.
+
+        """
+        result = await self._send_request(
+            api_name="list_data_origins",
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return DataOriginResponse.model_validate(result.result)
+
+    async def upsert_synchronizer(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        synchronizer: UpsertSynchronizerRequest,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Create or update a synchronizer on an index.
+
+        On create, this provisions the backing Atlas role, data connection, and data
+        consumer. On update, the credential owner may change the data selector or
+        credential bundle; a non-owner may only replace the credentials with their own.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name. Must match
+            ``^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$``.
+        :param synchronizer: The synchronizer configuration to upsert.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The upserted SynchronizerResponse.
+
+        :raises ValueError: If the synchronizer name contains invalid characters.
+
+        """
+        if not re.match(SYNCHRONIZER_NAME_PATTERN, synchronizer_name):
+            raise ValueError(f"Invalid synchronizer name '{synchronizer_name}', please avoid special characters.")
+        result = await self._send_request(
+            api_name="upsert_synchronizer",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            data=synchronizer,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
+
+    async def get_synchronizer(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Get a synchronizer and its current authentication status.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The requested SynchronizerResponse.
+
+        """
+        result = await self._send_request(
+            api_name="get_synchronizer",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
+
+    async def list_synchronizers(
+        self,
+        *,
+        index_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> ListSynchronizerResponse:
+        """
+        List all synchronizers on an index, regardless of which user created them.
+
+        :param index_name: The index to list synchronizers for.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A ListSynchronizerResponse with all synchronizers for the index.
+
+        """
+        result = await self._send_request(
+            api_name="list_synchronizers",
+            index_name=index_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return ListSynchronizerResponse.model_validate(result.result)
+
+    async def delete_synchronizer(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ):
+        """
+        Delete a synchronizer and clean up its Atlas resources.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        """
+        await self._send_request(
+            api_name="delete_synchronizer",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+
+    async def get_synchronizer_tree(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        tree_request: TreeRequest | None = None,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> TreeResponse:
+        """
+        Browse the tree structure of a synchronizer's data origin (e.g. folders).
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param tree_request: Which subtree to browse and how. Defaults to the root.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A TreeResponse with the requested tree entries.
+
+        """
+        result = await self._send_request(
+            api_name="get_synchronizer_tree",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            data=tree_request or TreeRequest(),
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return TreeResponse.model_validate(result.result)
+
+    async def get_synchronizer_oauth_url(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> OAuthResponse:
+        """
+        Get the OAuth authorization URL for a synchronizer's credential.
+
+        The credential owner visits this URL to authorize the data origin before
+        syncing can succeed.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            An OAuthResponse containing the authorization URL.
+
+        """
+        result = await self._send_request(
+            api_name="get_synchronizer_oauth_url",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return OAuthResponse.model_validate(result.result)
+
+    async def start_sync(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Start a sync job for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The SynchronizerResponse after the sync job has been started.
+
+        """
+        result = await self._send_request(
+            api_name="start_sync",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
+
+    async def get_sync_status(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> GetSyncStatusResponse:
+        """
+        Get the cumulative sync status for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A GetSyncStatusResponse with the cumulative sync status.
+
+        """
+        result = await self._send_request(
+            api_name="get_sync_status",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return GetSyncStatusResponse.model_validate(result.result)
+
+    async def get_latest_sync_job(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> GetLatestSyncJobResponse:
+        """
+        Get the latest sync job for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            A GetLatestSyncJobResponse with the most recent sync job.
+
+        """
+        result = await self._send_request(
+            api_name="get_latest_sync_job",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return GetLatestSyncJobResponse.model_validate(result.result)
+
+    async def cancel_sync(
+        self,
+        *,
+        index_name: str,
+        synchronizer_name: str,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SynchronizerResponse:
+        """
+        Cancel the current sync job for a synchronizer.
+
+        :param index_name: The index the synchronizer feeds.
+        :param synchronizer_name: The synchronizer name.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            The SynchronizerResponse after the sync job has been cancelled.
+
+        """
+        result = await self._send_request(
+            api_name="cancel_sync",
+            index_name=index_name,
+            synchronizer_name=synchronizer_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return SynchronizerResponse.model_validate(result.result)
 
     async def delete_document(
         self,

--- a/cohere_compass/models/__init__.py
+++ b/cohere_compass/models/__init__.py
@@ -46,3 +46,4 @@ from cohere_compass.models.indexes import (  # noqa: E402
     RetentionType as RetentionType,
 )
 from cohere_compass.models.search import *  # noqa: E402, F403
+from cohere_compass.models.synchronizers import *  # noqa: E402, F403

--- a/cohere_compass/models/synchronizers.py
+++ b/cohere_compass/models/synchronizers.py
@@ -1,0 +1,175 @@
+"""
+Models for synchronizer functionality in the Cohere Compass SDK.
+
+Synchronizers bind a Compass index to an external data origin (e.g. SharePoint,
+OneDrive) and let Atlas keep the index in sync. See the Compass synchronizer API
+for the access model and credential-owner semantics.
+"""
+
+import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Selector(BaseModel):
+    """A set of items to include or exclude when syncing a data origin."""
+
+    data_ids: list[str] | None = Field(
+        default=None,
+        description="Explicit data item IDs to match.",
+    )
+    patterns: list[str] | None = Field(
+        default=None,
+        description="Glob-style patterns to match against item paths.",
+    )
+
+
+class DataSelector(BaseModel):
+    """What to sync from a data origin, expressed as include/exclude selectors."""
+
+    include_selector: Selector | None = Field(
+        default=None,
+        description="Items to include. When omitted, the whole origin is eligible.",
+    )
+    exclude_selector: Selector | None = Field(
+        default=None,
+        description="Items to exclude from the included set.",
+    )
+
+
+class UpsertSynchronizerRequest(BaseModel):
+    """Request body for creating or updating a synchronizer."""
+
+    data_origin_id: str = Field(
+        description="Identifier of the data origin to sync (e.g. 'sharepoint', 'onedrive').",
+    )
+    data_selector: DataSelector | None = Field(
+        default=None,
+        description="What to sync from the data origin. Syncs the whole origin when omitted.",
+    )
+    credential_bundle_id: str = Field(
+        default="user-default",
+        description="Identifier for shared credentials. Synchronizers with the same "
+        "credential_bundle_id share a single upstream auth (Atlas role). Use a different "
+        "value to authenticate as a separate upstream identity.",
+    )
+
+
+class SynchronizerResponse(BaseModel):
+    """A synchronizer and its current authentication status."""
+
+    name: str = Field(description="The synchronizer name (unique within the index).")
+    credential_bundle_user_id: str | None = Field(
+        default=None,
+        description="User who owns the credential bundle in use; None when no bundle is assigned.",
+    )
+    index_name: str = Field(description="The index this synchronizer feeds.")
+    credential_bundle_id: str = Field(description="Identifier of the credential bundle in use.")
+    data_origin_id: str = Field(description="Identifier of the data origin being synced.")
+    data_selector: DataSelector | None = Field(
+        default=None,
+        description="What is being synced from the data origin.",
+    )
+    atlas_data_connection_id: str | None = Field(
+        default=None,
+        description="Atlas data connection backing this synchronizer.",
+    )
+    auth_status: str | None = Field(
+        default=None,
+        description="Authentication status of the credential owner: 'authenticated', "
+        "'not_authenticated', or None when unknown.",
+    )
+    created_at: datetime.datetime = Field(description="When the synchronizer was created.")
+    updated_at: datetime.datetime | None = Field(
+        default=None,
+        description="When the synchronizer was last updated.",
+    )
+
+
+class ListSynchronizerResponse(BaseModel):
+    """Response object for list_synchronizers."""
+
+    synchronizers: list[SynchronizerResponse]
+
+
+class DataOrigin(BaseModel):
+    """A supported data origin (e.g. SharePoint, OneDrive)."""
+
+    id: str = Field(description="Identifier used as data_origin_id when creating a synchronizer.")
+    name: str = Field(default="", description="Human-readable name of the data origin.")
+    description: str = Field(default="", description="Description of the data origin.")
+    uri: str | None = Field(default=None, description="Optional URI associated with the data origin.")
+
+
+class DataOriginResponse(BaseModel):
+    """Response object for list_data_origins."""
+
+    data_origins: list[DataOrigin]
+
+
+class TreeRequest(BaseModel):
+    """Request body for browsing a data origin's tree (e.g. folders)."""
+
+    root: str | None = Field(default=None, description="Selector path to browse from. None for the root.")
+    depth: int = Field(default=0, description="How many levels to descend. 0 returns the immediate children.")
+    page_size: int = Field(default=0, description="Maximum number of entries to return. 0 uses the server default.")
+    page_token: str = Field(default="", description="Pagination token from a previous response.")
+
+
+class TreeEntryResponse(BaseModel):
+    """A single entry (folder or item) in a data origin's tree."""
+
+    display_name: str = Field(description="Human-readable name of the entry.")
+    selector_path: str = Field(description="Path to use in a data selector to target this entry.")
+    type: str = Field(description="Entry type (e.g. folder or file).")
+    data_id: str | None = Field(default=None, description="Data item ID, when the entry is a syncable item.")
+    properties: dict[str, str] | None = Field(default=None, description="Additional entry properties.")
+
+
+class TreeResponse(BaseModel):
+    """Response object for get_synchronizer_tree."""
+
+    tree_entries: list[TreeEntryResponse]
+    page_token: str = Field(default="", description="Token to fetch the next page, empty when exhausted.")
+
+
+class FailedDataItemResponse(BaseModel):
+    """A data item that failed (or was skipped) during a sync."""
+
+    data_id: str = Field(description="Identifier of the failed item.")
+    error_message: str = Field(default="", description="Why the item failed.")
+    display_name: str = Field(default="", description="Human-readable name of the item.")
+    url: str = Field(default="", description="URL of the item, when available.")
+    is_skipped: bool = Field(default=False, description="Whether the item was skipped rather than errored.")
+
+
+class SyncStatusResponse(BaseModel):
+    """Cumulative status of a synchronizer's syncing."""
+
+    total_count: int = Field(default=0, description="Total number of items considered.")
+    done_count: int = Field(default=0, description="Number of items successfully synced.")
+    failed_items: list[FailedDataItemResponse] = Field(
+        default=[],
+        description="Items that failed or were skipped.",
+    )
+    last_sync_time: datetime.datetime | None = Field(default=None, description="When the last sync ran.")
+    last_sync_state: str | None = Field(default=None, description="State of the last sync.")
+
+
+class GetSyncStatusResponse(BaseModel):
+    """Response object for get_sync_status."""
+
+    sync_status: SyncStatusResponse | None = None
+
+
+class GetLatestSyncJobResponse(BaseModel):
+    """Response object for get_latest_sync_job."""
+
+    latest_sync_job: dict[str, Any] | None = None
+
+
+class OAuthResponse(BaseModel):
+    """Response object for get_synchronizer_oauth_url."""
+
+    auth_url: str = Field(description="URL the credential owner visits to authorize the data origin.")

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,14 +7,14 @@ examples provided can mostly be run directly or with minor modifications.
 
 ## Getting Started
 
-Like the `compass-sdk`, this package uses `poetry` for dependency management. To start
-using it, execute:
+Like the `cohere-compass-sdk`, this package uses `poetry` for dependency
+management. To start using it, execute:
 
 ```
 poetry sync
 ```
 
-This package references the `compass-sdk` locally (i.e. installed via `poetry add -e
+This package references the `cohere-compass-sdk` locally (i.e. installed via `poetry add -e
 ../`), so you might need to execute `poetry sync` on the parent folder as well.
 
 Note: If you don't have `poetry`, head over to the [poetry installation
@@ -26,9 +26,9 @@ the bearer tokens if your Compass instance has multi-tenancy enabled. Example
 .env file below:
 
 ```
-COMPASS_API_URL=http://<your compass API URL>/
+COMPASS_API_URL=https://<your compass API URL>
 COMPASS_API_BEARER_TOKEN=
-COMPASS_PARSER_URL=http://<your compass parser URL>/
+COMPASS_PARSER_URL=https://<your compass parser URL>
 COMPASS_PARSER_BEARER_TOKEN=
 ```
 
@@ -37,5 +37,5 @@ COMPASS_PARSER_BEARER_TOKEN=
 To run an example, e.g. `list_indexes.py`, simply execute the following command:
 
 ```
-poetry run python -m cohere_sdk_examples.list_indexes
+poetry run python -m compass_sdk_examples.list_indexes
 ```

--- a/examples/compass_sdk_examples/synchronizer.py
+++ b/examples/compass_sdk_examples/synchronizer.py
@@ -1,0 +1,144 @@
+import argparse
+import json
+
+from cohere_compass.models import UpsertSynchronizerRequest
+
+from compass_sdk_examples.utils import get_compass_client
+
+
+def parse_args():
+    """
+    Parse the user arguments using argparse.
+    """
+    parser = argparse.ArgumentParser(
+        description="""
+Manage synchronizers for a Compass index.
+
+A synchronizer binds an index to an external data origin (e.g. SharePoint, OneDrive)
+and lets Atlas keep the index in sync. The typical flow is:
+
+  1. origins              -> discover available data origins
+  2. create               -> create a synchronizer
+  3. auth-url             -> get the OAuth URL and authorize in a browser
+  4. sync                 -> start a sync job
+  5. status               -> poll cumulative sync status
+""".strip(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--index-name", type=str, required=True, help="Name of the index."
+    )
+    parser.add_argument("--name", type=str, help="Name of the synchronizer.")
+
+    subparsers = parser.add_subparsers(dest="action", help="Action to perform")
+
+    subparsers.add_parser("origins", help="List supported data origins")
+
+    create_parser = subparsers.add_parser(
+        "create", help="Create or update a synchronizer"
+    )
+    create_parser.add_argument(
+        "--data-origin-id", type=str, required=True, help="e.g. 'sharepoint'."
+    )
+    create_parser.add_argument(
+        "--credential-bundle-id",
+        type=str,
+        default="user-default",
+        help="Credential bundle identifier (default: user-default).",
+    )
+
+    subparsers.add_parser("get", help="Get a synchronizer")
+    subparsers.add_parser("list", help="List all synchronizers for the index")
+    subparsers.add_parser("delete", help="Delete a synchronizer")
+    subparsers.add_parser("auth-url", help="Get the OAuth authorization URL")
+    subparsers.add_parser("sync", help="Start a sync job")
+    subparsers.add_parser("status", help="Get cumulative sync status")
+
+    return parser.parse_args()
+
+
+def _require_name(args: argparse.Namespace) -> str:
+    if not args.name:
+        raise SystemExit("--name is required for this action.")
+    return args.name
+
+
+def main():
+    args = parse_args()
+    index_name = args.index_name
+    client = get_compass_client()
+
+    if args.action == "origins":
+        origins = client.list_data_origins().data_origins
+        print("Supported data origins:")
+        for origin in origins:
+            print(f"  {origin.id}: {origin.name}")
+
+    elif args.action == "create":
+        name = _require_name(args)
+        synchronizer = client.upsert_synchronizer(
+            index_name=index_name,
+            synchronizer_name=name,
+            synchronizer=UpsertSynchronizerRequest(
+                data_origin_id=args.data_origin_id,
+                credential_bundle_id=args.credential_bundle_id,
+            ),
+        )
+        print(
+            f"Created synchronizer '{synchronizer.name}' "
+            f"(auth_status={synchronizer.auth_status})."
+        )
+        print("Next: run 'auth-url' to authorize, then 'sync' to start syncing.")
+
+    elif args.action == "get":
+        synchronizer = client.get_synchronizer(
+            index_name=index_name, synchronizer_name=_require_name(args)
+        )
+        print(json.dumps(synchronizer.model_dump(mode="json"), indent=2))
+
+    elif args.action == "list":
+        synchronizers = client.list_synchronizers(index_name=index_name).synchronizers
+        for synchronizer in synchronizers:
+            print(
+                f"  {synchronizer.name}: origin={synchronizer.data_origin_id} "
+                f"auth={synchronizer.auth_status}"
+            )
+
+    elif args.action == "delete":
+        client.delete_synchronizer(
+            index_name=index_name, synchronizer_name=_require_name(args)
+        )
+        print("Synchronizer deleted.")
+
+    elif args.action == "auth-url":
+        oauth = client.get_synchronizer_oauth_url(
+            index_name=index_name, synchronizer_name=_require_name(args)
+        )
+        print("Open this URL in a browser to authorize the data origin:")
+        print(oauth.auth_url)
+
+    elif args.action == "sync":
+        client.start_sync(index_name=index_name, synchronizer_name=_require_name(args))
+        print("Sync job started.")
+
+    elif args.action == "status":
+        name = _require_name(args)
+        status = client.get_sync_status(
+            index_name=index_name, synchronizer_name=name
+        ).sync_status
+        if status is None:
+            print("No sync status available yet.")
+        else:
+            print(
+                f"Progress: {status.done_count}/{status.total_count} "
+                f"(state={status.last_sync_state})"
+            )
+            for item in status.failed_items:
+                print(f"  failed: {item.data_id} - {item.error_message}")
+
+    else:
+        print("Please specify an action. Use --help for more information.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.12.5"
+version = "2.13.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -41,6 +41,14 @@ from cohere_compass.models.search import (
     AssetInfo,
     SortBy,
 )
+from cohere_compass.models.synchronizers import (
+    DataOrigin,
+    DataSelector,
+    Selector,
+    SynchronizerResponse,
+    TreeRequest,
+    UpsertSynchronizerRequest,
+)
 from tests.utils import SyncifiedCompassAsyncClient
 
 HTTPMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
@@ -1341,3 +1349,226 @@ def test_set_retention_policy_sends_correct_body(client: CompassClient):
 )
 def test_delete_retention_policy_sends_request(client: CompassClient):
     client.delete_retention_policy(index_name="test_index")
+
+
+# ── Synchronizers ────────────────────────────────────────────────────
+
+_SYNCHRONIZER_BODY = {
+    "name": "test_sync",
+    "index_name": "test_index",
+    "credential_bundle_id": "user-default",
+    "credential_bundle_user_id": "alice",
+    "data_origin_id": "sharepoint",
+    "data_selector": None,
+    "atlas_data_connection_id": "conn-1",
+    "auth_status": "authenticated",
+    "created_at": "2024-01-27T10:14:00Z",
+    "updated_at": "2024-01-27T10:14:00Z",
+}
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/synchronizers/data-origins",
+    200,
+    response_body={
+        "data_origins": [
+            {"id": "sharepoint", "name": "SharePoint", "description": "", "uri": None},
+            {"id": "onedrive", "name": "OneDrive"},
+        ]
+    },
+)
+def test_list_data_origins(client: CompassClient):
+    result = client.list_data_origins()
+    assert result.data_origins == [
+        DataOrigin(id="sharepoint", name="SharePoint"),
+        DataOrigin(id="onedrive", name="OneDrive"),
+    ]
+
+
+@mock_endpoint(
+    "PUT",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync",
+    200,
+    response_body=_SYNCHRONIZER_BODY,
+    expected_request_body={
+        "data_origin_id": "sharepoint",
+        "credential_bundle_id": "user-default",
+    },
+)
+def test_upsert_synchronizer_sends_correct_body(client: CompassClient):
+    result = client.upsert_synchronizer(
+        index_name="test_index",
+        synchronizer_name="test_sync",
+        synchronizer=UpsertSynchronizerRequest(data_origin_id="sharepoint"),
+    )
+    assert isinstance(result, SynchronizerResponse)
+    assert result.name == "test_sync"
+    assert result.auth_status == "authenticated"
+
+
+@mock_endpoint(
+    "PUT",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync",
+    200,
+    response_body=_SYNCHRONIZER_BODY,
+    expected_request_body={
+        "data_origin_id": "sharepoint",
+        "credential_bundle_id": "team",
+        "data_selector": {"include_selector": {"patterns": ["docs/**"]}},
+    },
+)
+def test_upsert_synchronizer_with_selector_and_bundle(client: CompassClient):
+    client.upsert_synchronizer(
+        index_name="test_index",
+        synchronizer_name="test_sync",
+        synchronizer=UpsertSynchronizerRequest(
+            data_origin_id="sharepoint",
+            credential_bundle_id="team",
+            data_selector=DataSelector(include_selector=Selector(patterns=["docs/**"])),
+        ),
+    )
+
+
+@respx.mock
+def test_upsert_synchronizer_with_invalid_name(client: CompassClient, respx_mock: MockRouter):
+    with pytest.raises(ValueError) as exc_info:
+        client.upsert_synchronizer(
+            index_name="test_index",
+            synchronizer_name="has/slashes",
+            synchronizer=UpsertSynchronizerRequest(data_origin_id="sharepoint"),
+        )
+    assert "Invalid synchronizer name" in str(exc_info.value)
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync",
+    200,
+    response_body=_SYNCHRONIZER_BODY,
+)
+def test_get_synchronizer(client: CompassClient):
+    result = client.get_synchronizer(index_name="test_index", synchronizer_name="test_sync")
+    assert result.name == "test_sync"
+    assert result.credential_bundle_user_id == "alice"
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/synchronizers",
+    200,
+    response_body={"synchronizers": [_SYNCHRONIZER_BODY]},
+)
+def test_list_synchronizers(client: CompassClient):
+    result = client.list_synchronizers(index_name="test_index")
+    assert len(result.synchronizers) == 1
+    assert result.synchronizers[0].name == "test_sync"
+
+
+@mock_endpoint(
+    "DELETE",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync",
+    204,
+)
+def test_delete_synchronizer(client: CompassClient):
+    client.delete_synchronizer(index_name="test_index", synchronizer_name="test_sync")
+
+
+@mock_endpoint(
+    "POST",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync/tree",
+    200,
+    response_body={
+        "tree_entries": [
+            {"display_name": "Docs", "selector_path": "/docs", "type": "folder"},
+        ],
+        "page_token": "next",
+    },
+    expected_request_body={"depth": 1, "page_size": 0, "page_token": ""},
+)
+def test_get_synchronizer_tree(client: CompassClient):
+    result = client.get_synchronizer_tree(
+        index_name="test_index",
+        synchronizer_name="test_sync",
+        tree_request=TreeRequest(depth=1),
+    )
+    assert result.page_token == "next"
+    assert result.tree_entries[0].display_name == "Docs"
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync/oauth/auth",
+    200,
+    response_body={"auth_url": "https://idp.example.com/authorize?x=1"},
+)
+def test_get_synchronizer_oauth_url(client: CompassClient):
+    result = client.get_synchronizer_oauth_url(index_name="test_index", synchronizer_name="test_sync")
+    assert result.auth_url == "https://idp.example.com/authorize?x=1"
+
+
+@mock_endpoint(
+    "POST",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync/sync",
+    200,
+    response_body=_SYNCHRONIZER_BODY,
+)
+def test_start_sync(client: CompassClient):
+    result = client.start_sync(index_name="test_index", synchronizer_name="test_sync")
+    assert result.name == "test_sync"
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync/sync",
+    200,
+    response_body={
+        "sync_status": {
+            "total_count": 10,
+            "done_count": 7,
+            "failed_items": [],
+            "last_sync_time": "2024-01-27T10:14:00Z",
+            "last_sync_state": "running",
+        }
+    },
+)
+def test_get_sync_status(client: CompassClient):
+    result = client.get_sync_status(index_name="test_index", synchronizer_name="test_sync")
+    assert result.sync_status is not None
+    assert result.sync_status.total_count == 10
+    assert result.sync_status.done_count == 7
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync/sync/latest-job",
+    200,
+    response_body={"latest_sync_job": {"id": "job-1", "state": "running"}},
+)
+def test_get_latest_sync_job(client: CompassClient):
+    result = client.get_latest_sync_job(index_name="test_index", synchronizer_name="test_sync")
+    assert result.latest_sync_job == {"id": "job-1", "state": "running"}
+
+
+@mock_endpoint(
+    "POST",
+    "http://test.com/v1/indexes/test_index/synchronizers/test_sync/cancel",
+    200,
+    response_body=_SYNCHRONIZER_BODY,
+)
+def test_cancel_sync(client: CompassClient):
+    result = client.cancel_sync(index_name="test_index", synchronizer_name="test_sync")
+    assert result.name == "test_sync"
+
+
+@respx.mock
+def test_upsert_synchronizer_409_propagated_to_caller(client: CompassClient, respx_mock: MockRouter):
+    respx_mock.put("http://test.com/v1/indexes/test_index/synchronizers/test_sync").mock(
+        return_value=httpx.Response(409, json={"error": "data_origin_id cannot change"})
+    )
+    with pytest.raises(CompassError):
+        client.upsert_synchronizer(
+            index_name="test_index",
+            synchronizer_name="test_sync",
+            synchronizer=UpsertSynchronizerRequest(data_origin_id="onedrive"),
+        )


### PR DESCRIPTION
Wraps the synchronizer API, adds examples, fixes some linter complaints
along the way.

# Test

```
$ poetry run python -m compass_sdk_examples.synchronizer --index-name hello list
  two: origin=onedrive auth=authenticated
  mysynchronizer: origin=onedrive auth=authenticated
  filesystemchronizer: origin=filesystem auth=not_authenticated

$ poetry run python -m compass_sdk_examples.synchronizer --index-name hello --name sdktest create --data-origin-id sharepoint 
Created synchronizer 'sdktest' (auth_status=not_authenticated).
Next: run 'auth-url' to authorize, then 'sync' to start syncing.

$ poetry run python -m compass_sdk_examples.synchronizer --index-name hello --name sdktest auth-url
Open this URL in a browser to authorize the data origin:
<REDACTED>

$ poetry run python -m compass_sdk_examples.synchronizer --index-name hello --name sdktest sync
Sync job started.

$ poetry run python -m compass_sdk_examples.synchronizer --index-name hello --name sdktest status
Progress: 0/78 (state=ACTIVE)

$ poetry run python -m compass_sdk_examples.synchronizer --index-name hello --name sdktest status
Progress: 7/1631 (state=ACTIVE)
```
