### PR TITLE
feat: Add batch_get_documents method to Compass clients

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -83,6 +83,8 @@ from cohere_compass.models.documents import (
 )
 from cohere_compass.models.indexes import IndexDetails, ListIndexesResponse, RetentionPolicy
 from cohere_compass.models.search import (
+    BatchGetDocumentsRequest,
+    BatchGetDocumentsResponse,
     GetDocumentResponse,
     RetrievedDocument,
     SortBy,
@@ -162,6 +164,10 @@ API_DEFINITIONS = {
     "get_document": (
         "GET",
         "indexes/{index_name}/documents/{document_id}",
+    ),
+    "batch_get_documents": (
+        "POST",
+        "indexes/{index_name}/documents/_batch_get",
     ),
     "put_documents": (
         "PUT",
@@ -1086,6 +1092,44 @@ class CompassClient:
         )
         response = GetDocumentResponse.model_validate(result.result)
         return response.document
+
+    def batch_get_documents(
+        self,
+        *,
+        index_name: str,
+        document_ids: list[str],
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> BatchGetDocumentsResponse:
+        """
+        Retrieve multiple documents from Compass by their IDs in a single request.
+
+        Documents that are not found are silently omitted from the response; a not-found
+        error is only raised when none of the requested IDs exist in the index.
+
+        :param index_name: The name of the index containing the documents.
+        :param document_ids: List of document IDs to retrieve.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            BatchGetDocumentsResponse containing the list of retrieved documents.
+
+        """
+        result = self._send_request(
+            api_name="batch_get_documents",
+            data=BatchGetDocumentsRequest(document_ids=document_ids),
+            index_name=index_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return BatchGetDocumentsResponse.model_validate(result.result)
 
     def list_indexes(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -83,7 +83,13 @@ from cohere_compass.models.documents import (
     UploadFilePresignedUrlResponse,
 )
 from cohere_compass.models.indexes import IndexDetails, ListIndexesResponse, RetentionPolicy
-from cohere_compass.models.search import GetDocumentResponse, RetrievedDocument, SortBy
+from cohere_compass.models.search import (
+    BatchGetDocumentsRequest,
+    BatchGetDocumentsResponse,
+    GetDocumentResponse,
+    RetrievedDocument,
+    SortBy,
+)
 from cohere_compass.models.synchronizers import (
     DataOriginResponse,
     GetLatestSyncJobResponse,
@@ -897,6 +903,44 @@ class CompassAsyncClient:
         )
         response = GetDocumentResponse.model_validate(result.result)
         return response.document
+
+    async def batch_get_documents(
+        self,
+        *,
+        index_name: str,
+        document_ids: list[str],
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> BatchGetDocumentsResponse:
+        """
+        Retrieve multiple documents from Compass by their IDs in a single request.
+
+        Documents that are not found are silently omitted from the response; a not-found
+        error is only raised when none of the requested IDs exist in the index.
+
+        :param index_name: The name of the index containing the documents.
+        :param document_ids: List of document IDs to retrieve.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        Returns:
+            BatchGetDocumentsResponse containing the list of retrieved documents.
+
+        """
+        result = await self._send_request(
+            api_name="batch_get_documents",
+            data=BatchGetDocumentsRequest(document_ids=document_ids),
+            index_name=index_name,
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        return BatchGetDocumentsResponse.model_validate(result.result)
 
     async def list_indexes(
         self,

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -95,6 +95,18 @@ class GetDocumentResponse(BaseModel):
     document: RetrievedDocument
 
 
+class BatchGetDocumentsRequest(BaseModel):
+    """Request body for batch_get_documents API."""
+
+    document_ids: list[str]
+
+
+class BatchGetDocumentsResponse(BaseModel):
+    """Response object for batch_get_documents API."""
+
+    documents: list[RetrievedDocument]
+
+
 class SearchDocumentsResponse(BaseModel):
     """Response object for search_documents API."""
 

--- a/examples/compass_sdk_examples/async/batch_get_documents.py
+++ b/examples/compass_sdk_examples/async/batch_get_documents.py
@@ -1,0 +1,60 @@
+import argparse
+import asyncio
+
+from compass_sdk_examples.utils import get_compass_client_async
+
+
+def parse_args():
+    """
+    Parse the user arguments using argparse.
+    """
+    parser = argparse.ArgumentParser(
+        description="Retrieve multiple documents from a Compass index in a single request."
+    )
+    parser.add_argument(
+        "--index-name",
+        type=str,
+        help="Specify the name of the index.",
+        required=True,
+    )
+    parser.add_argument(
+        "--document-ids",
+        type=str,
+        nargs="+",
+        help="One or more document IDs to retrieve.",
+        required=True,
+    )
+
+    return parser.parse_args()
+
+
+async def main():
+    args = parse_args()
+    index_name = args.index_name
+    document_ids = args.document_ids
+
+    client = get_compass_client_async()
+
+    try:
+        print(
+            f"Retrieving {len(document_ids)} document(s) from index '{index_name}'..."
+        )
+        result = await client.batch_get_documents(
+            index_name=index_name, document_ids=document_ids
+        )
+
+        print(f"Found {len(result.documents)} document(s):\n")
+        for doc in result.documents:
+            print(doc.model_dump_json(indent=2))
+
+    except Exception as e:
+        import traceback
+
+        traceback.print_exc()
+        print(f"Error retrieving documents: {e}")
+    finally:
+        await client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/compass_sdk_examples/batch_get_documents.py
+++ b/examples/compass_sdk_examples/batch_get_documents.py
@@ -1,0 +1,57 @@
+import argparse
+
+from compass_sdk_examples.utils import get_compass_client
+
+
+def parse_args():
+    """
+    Parse the user arguments using argparse.
+    """
+    parser = argparse.ArgumentParser(
+        description="Retrieve multiple documents from a Compass index in a single request."
+    )
+    parser.add_argument(
+        "--index-name",
+        type=str,
+        help="Specify the name of the index.",
+        required=True,
+    )
+    parser.add_argument(
+        "--document-ids",
+        type=str,
+        nargs="+",
+        help="One or more document IDs to retrieve.",
+        required=True,
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    index_name = args.index_name
+    document_ids = args.document_ids
+
+    client = get_compass_client()
+
+    try:
+        print(
+            f"Retrieving {len(document_ids)} document(s) from index '{index_name}'..."
+        )
+        result = client.batch_get_documents(
+            index_name=index_name, document_ids=document_ids
+        )
+
+        print(f"Found {len(result.documents)} document(s):\n")
+        for doc in result.documents:
+            print(doc.model_dump_json(indent=2))
+
+    except Exception as e:
+        import traceback
+
+        traceback.print_exc()
+        print(f"Error retrieving documents: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces the `batch_get_documents` API to the Compass SDK, allowing users to retrieve multiple documents from a Compass index in a single request.

- **New API Endpoint**: Added `batch_get_documents` endpoint to both `compass.py` and `compass_async.py`, enabling batch retrieval of documents by their IDs.
- **Request and Response Models**: Introduced `BatchGetDocumentsRequest` and `BatchGetDocumentsResponse` models in `search.py` to handle the API's request and response structures.
- **Example Scripts**: Added example scripts for both synchronous and asynchronous usage of the new API, demonstrating how to retrieve multiple documents in a single request.
- **Error Handling**: Implemented error handling to manage cases where documents are not found, ensuring that only relevant errors are raised.

<!-- end-generated-description -->