### PR TITLE
feat: add RAW asset type and sync enums with Compass API

### DIFF
--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -125,6 +125,7 @@ class DocxParsingStrategy(str, Enum):
 class ParsingStrategy(str, Enum):
     """Enum for specifying the parsing strategy to use."""
 
+    Auto = "auto"
     Fast = "fast"
     Hi_Res = "hi_res"
 
@@ -136,8 +137,8 @@ class ParsingStrategy(str, Enum):
 class ParsingModel(str, Enum):
     """Enum for specifying the parsing model to use."""
 
-    # Default model, which is actually a combination of models used by the "Marker" PDF
-    # parser
+    # Deprecated: Marker is retained for backward compatibility; the server currently
+    # accepts yolox_quantized for PDF parsing.
     Marker = "marker"
     # Only PDF parsing working option from Unstructured
     YoloX_Quantized = "yolox_quantized"

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -53,6 +53,8 @@ class AssetType(str, Enum):
     VIDEO = "video"
     # An audio asset type
     AUDIO = "audio"
+    # The original uploaded file bytes (when enable_raw_file_asset is on)
+    RAW = "raw"
 
     @classmethod
     def __get_pydantic_json_schema__(cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
@@ -488,6 +490,8 @@ class ContentTypeEnum(str, Enum):
     ApplicationMsOutlook = "application/vnd.ms-outlook"
     ApplicationOctetStream = "application/octet-stream"
     ApplicationRtf = "application/rtf"
+    # Pre-parsed CompassDocument JSON (upload with this MIME to skip parsing).
+    ApplicationVndCohereCompassV1Json = "application/vnd.cohere.compassV1+json"
     # HWP types
     ApplicationXHwp = "application/x-hwp"
     ApplicationXHwpx = "application/x-hwpx"
@@ -505,6 +509,7 @@ class ContentTypeEnum(str, Enum):
     # Audio types
     AudioMpeg = "audio/mpeg"
     AudioWav = "audio/wav"
+    AudioMp3 = "audio/mp3"
 
     # Video types
     VideoMp4 = "video/mp4"

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Literal, cast
 
 # 3rd party imports
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from cohere_compass.models.documents import AssetType
 
@@ -26,7 +26,14 @@ class AssetInfo(BaseModel):
     asset_id: str | None = None
     asset_type: AssetType
     content_type: str
-    presigned_url: str
+    presigned_url: str = Field(
+        default="",
+        deprecated=True,
+        description=(
+            'Deprecated: use get_asset_presigned_urls ("/{index_name}/assets/_presigned_urls") instead. '
+            "May be empty for AUDIO, VIDEO, and RAW assets."
+        ),
+    )
     visual_elements: list[VisualElement] | None = None
 
     @model_validator(mode="before")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.13.0"
+version = "2.14.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -1208,6 +1208,60 @@ def test_asset_info_with_presigned_url():
     assert asset.presigned_url == "https://example.com/asset"
 
 
+def test_asset_info_accepts_raw_asset_type():
+    """RAW is returned by search when enable_raw_file_asset is enabled on the server."""
+    asset = AssetInfo.model_validate(
+        {
+            "asset_type": AssetType.RAW,
+            "content_type": "application/pdf",
+            "presigned_url": "https://example.com/raw.pdf",
+        }
+    )
+    assert asset.asset_type == AssetType.RAW
+
+
+def test_search_chunks_response_accepts_raw_assets_info():
+    from cohere_compass.models.search import SearchChunksResponse
+
+    response = SearchChunksResponse.model_validate(
+        {
+            "hits": [
+                {
+                    "chunk_id": "doc/1",
+                    "sort_id": 0,
+                    "parent_document_id": "doc",
+                    "path": "example.pdf",
+                    "content": {"text": "hello"},
+                    "origin": {},
+                    "score": 1.0,
+                    "document_id": "doc",
+                    "assets_info": [
+                        {
+                            "asset_type": "raw",
+                            "content_type": "application/pdf",
+                            "presigned_url": "https://example.com/raw.pdf",
+                            "asset_id": "00000000-0000-0000-0000-000000000001",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    assert response.hits[0].assets_info is not None
+    assert response.hits[0].assets_info[0].asset_type == AssetType.RAW
+
+
+def test_content_type_enum_includes_compass_v1_json_and_audio_mp3():
+    assert ContentTypeEnum.ApplicationVndCohereCompassV1Json == "application/vnd.cohere.compassV1+json"
+    assert ContentTypeEnum.AudioMp3 == "audio/mp3"
+
+
+def test_parsing_strategy_includes_auto():
+    from cohere_compass.models.config import ParsingStrategy
+
+    assert ParsingStrategy.Auto == "auto"
+
+
 # ── Client: upload_document with file_data_uuid ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

Syncs client-facing enums with the Compass server after `asset_type: raw` started appearing in search responses (when `enable_raw_file_asset` is enabled). This fixes SDK pydantic validation failures in e2e tests such as `test_nfs_sync`.

## Enum audit (Compass server vs SDK)

| Enum | Gap | Action |
|------|-----|--------|
| `AssetType` | Server returns `raw`; SDK missing | **Add `RAW`** |
| `ContentTypeEnum` | Server has `application/vnd.cohere.compassV1+json`, `audio/mp3` | **Add both** |
| `ParsingStrategy` | Parser accepts `auto`; SDK missing | **Add `Auto`** |
| `ParsingModel.Marker` | Server/parser only uses `yolox_quantized` | **Keep; mark deprecated in docstring** |
| `FilterType`, `RetentionType`, tabular/PDF/presentation/docx strategies | In sync | No change |
| Internal storage asset types (`parsed_doc`, `chunks`, etc.) | Not exposed in search `assets_info` wire model | Not added to SDK |

## Changes

- `AssetType.RAW = "raw"`
- `ContentTypeEnum.ApplicationVndCohereCompassV1Json`, `AudioMp3`
- `ParsingStrategy.Auto = "auto"`
- `AssetInfo.presigned_url` marked `deprecated=True` (server already deprecates; field kept for back-compat)
- `ParsingModel.Marker` docstring notes deprecation
- Version bump **2.13.0 → 2.14.0**

## Testing

```bash
poetry run pytest
```

231 passed locally.