### PR TITLE
feat: add RAW asset type, audio/mp3 content type, drop ParsingModel/Strategy

### DIFF
--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -122,35 +122,8 @@ class DocxParsingStrategy(str, Enum):
         return cls.MarkItDown
 
 
-class ParsingStrategy(str, Enum):
-    """Enum for specifying the parsing strategy to use."""
-
-    Auto = "auto"
-    Fast = "fast"
-    Hi_Res = "hi_res"
-
-    @classmethod
-    def _missing_(cls, value: Any):
-        return cls.Fast
-
-
 class ParserConfig(BaseModel):
-    """
-    A model class for specifying parsing configuration.
-
-    Important parameters:
-
-    :param parsing_strategy: the parsing strategy to use:
-        - 'auto' (default): automatically determine the best strategy
-        - 'fast': leverage traditional NLP extraction techniques to quickly pull all the
-          text elements. “Fast” strategy is not good for image based file types.
-        - 'hi_res': identifies the layout of the document using detectron2. The
-          advantage of “hi_res” is that it uses the document layout to gain additional
-          information about document elements.  We recommend using this strategy if your
-          use case is highly sensitive to correct classifications for document elements.
-        - 'ocr_only': leverage Optical Character Recognition to extract text from the
-          image based files.
-    """
+    """A model class for specifying parsing configuration."""
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -162,7 +135,6 @@ class ParserConfig(BaseModel):
     allowed_image_types: list[str] | None = None
     min_chars_per_element: int = DEFAULT_MIN_CHARS_PER_ELEMENT
     skip_infer_table_types: list[str] = SKIP_INFER_TABLE_TYPES
-    parsing_strategy: ParsingStrategy = ParsingStrategy.Fast
 
     # CompassChunker configuration
     num_tokens_per_chunk: int = DEFAULT_NUM_TOKENS_PER_CHUNK

--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -125,26 +125,13 @@ class DocxParsingStrategy(str, Enum):
 class ParsingStrategy(str, Enum):
     """Enum for specifying the parsing strategy to use."""
 
+    Auto = "auto"
     Fast = "fast"
     Hi_Res = "hi_res"
 
     @classmethod
     def _missing_(cls, value: Any):
         return cls.Fast
-
-
-class ParsingModel(str, Enum):
-    """Enum for specifying the parsing model to use."""
-
-    # Default model, which is actually a combination of models used by the "Marker" PDF
-    # parser
-    Marker = "marker"
-    # Only PDF parsing working option from Unstructured
-    YoloX_Quantized = "yolox_quantized"
-
-    @classmethod
-    def _missing_(cls, value: Any):
-        return cls.Marker
 
 
 class ParserConfig(BaseModel):
@@ -163,12 +150,6 @@ class ParserConfig(BaseModel):
           use case is highly sensitive to correct classifications for document elements.
         - 'ocr_only': leverage Optical Character Recognition to extract text from the
           image based files.
-    :param parsing_model: the parsing model to use. One of:
-        - yolox_quantized (default): single-stage object detection model, quantized.
-          Runs faster than YoloX. See
-          https://unstructured-io.github.io/unstructured/best_practices/models.html for
-          more details. We have temporarily removed the option to use other models
-          because of ongoing stability issues.
     """
 
     model_config = ConfigDict(
@@ -182,7 +163,6 @@ class ParserConfig(BaseModel):
     min_chars_per_element: int = DEFAULT_MIN_CHARS_PER_ELEMENT
     skip_infer_table_types: list[str] = SKIP_INFER_TABLE_TYPES
     parsing_strategy: ParsingStrategy = ParsingStrategy.Fast
-    parsing_model: ParsingModel = ParsingModel.YoloX_Quantized
 
     # CompassChunker configuration
     num_tokens_per_chunk: int = DEFAULT_NUM_TOKENS_PER_CHUNK

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -490,8 +490,6 @@ class ContentTypeEnum(str, Enum):
     ApplicationMsOutlook = "application/vnd.ms-outlook"
     ApplicationOctetStream = "application/octet-stream"
     ApplicationRtf = "application/rtf"
-    # Pre-parsed CompassDocument JSON (upload with this MIME to skip parsing).
-    ApplicationVndCohereCompassV1Json = "application/vnd.cohere.compassV1+json"
     # HWP types
     ApplicationXHwp = "application/x-hwp"
     ApplicationXHwpx = "application/x-hwpx"

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -53,6 +53,8 @@ class AssetType(str, Enum):
     VIDEO = "video"
     # An audio asset type
     AUDIO = "audio"
+    # The original uploaded file bytes (when enable_raw_file_asset is on)
+    RAW = "raw"
 
     @classmethod
     def __get_pydantic_json_schema__(cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
@@ -488,6 +490,8 @@ class ContentTypeEnum(str, Enum):
     ApplicationMsOutlook = "application/vnd.ms-outlook"
     ApplicationOctetStream = "application/octet-stream"
     ApplicationRtf = "application/rtf"
+    # Pre-parsed CompassDocument JSON (upload with this MIME to skip parsing).
+    ApplicationVndCohereCompassV1Json = "application/vnd.cohere.compassV1+json"
     # HWP types
     ApplicationXHwp = "application/x-hwp"
     ApplicationXHwpx = "application/x-hwpx"
@@ -505,6 +509,7 @@ class ContentTypeEnum(str, Enum):
     # Audio types
     AudioMpeg = "audio/mpeg"
     AudioWav = "audio/wav"
+    AudioMp3 = "audio/mp3"
 
     # Video types
     VideoMp4 = "video/mp4"

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Literal, cast
 
 # 3rd party imports
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from cohere_compass.models.documents import AssetType
 
@@ -26,7 +26,14 @@ class AssetInfo(BaseModel):
     asset_id: str | None = None
     asset_type: AssetType
     content_type: str
-    presigned_url: str
+    presigned_url: str = Field(
+        default="",
+        deprecated=True,
+        description=(
+            'Deprecated: use get_asset_presigned_urls ("/{index_name}/assets/_presigned_urls") instead. '
+            "May be empty for AUDIO, VIDEO, and RAW assets."
+        ),
+    )
     visual_elements: list[VisualElement] | None = None
 
     @model_validator(mode="before")

--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Literal, cast
 
 # 3rd party imports
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, model_validator
 
 from cohere_compass.models.documents import AssetType
 
@@ -26,14 +26,7 @@ class AssetInfo(BaseModel):
     asset_id: str | None = None
     asset_type: AssetType
     content_type: str
-    presigned_url: str = Field(
-        default="",
-        deprecated=True,
-        description=(
-            'Deprecated: use get_asset_presigned_urls ("/{index_name}/assets/_presigned_urls") instead. '
-            "May be empty for AUDIO, VIDEO, and RAW assets."
-        ),
-    )
+    presigned_url: str
     visual_elements: list[VisualElement] | None = None
 
     @model_validator(mode="before")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.13.0"
+version = "2.14.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
Syncs client-facing enums with the Compass server, to support asset type `raw`, content type `audio/mp3`.

Also remove fully deprecated/unused `ParsingModel` and `ParsingStrategy`. `ParserConfig` model validation will ignore these fields if populated by old clients.

Version bump **2.13.0 → 2.14.0**