### PR TITLE
fix: add asset_id to the visual element so North fetches the right asset

### DIFF
--- a/cohere_compass/models/search.py
+++ b/cohere_compass/models/search.py
@@ -18,6 +18,7 @@ class VisualElement(BaseModel):
     y0: int
     x1: int
     y1: int
+    asset_id: str | None = None
 
 
 class AssetInfo(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.14.0"
+version = "2.15.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -40,6 +40,7 @@ from cohere_compass.models.indexes import (
 from cohere_compass.models.search import (
     AssetInfo,
     SortBy,
+    VisualElement,
 )
 from cohere_compass.models.synchronizers import (
     DataOrigin,
@@ -1206,6 +1207,39 @@ def test_asset_info_with_presigned_url():
         }
     )
     assert asset.presigned_url == "https://example.com/asset"
+
+
+# ── VisualElement asset_id ───────────────────────────────────────────────
+
+
+def test_visual_element_carries_asset_id():
+    """The visual element repeats its owning asset_id so it sits beside the element's coordinates."""
+    element = VisualElement.model_validate(
+        {"id": 1, "x0": 72, "y0": 100, "x1": 924, "y1": 215, "asset_id": "b77a2254-c0ae-4005-bad1-fa86ff15675f"}
+    )
+    assert element.asset_id == "b77a2254-c0ae-4005-bad1-fa86ff15675f"
+
+
+def test_visual_element_asset_id_defaults_to_none_when_absent():
+    """Responses from older servers omit asset_id; the field stays None rather than failing to parse."""
+    element = VisualElement.model_validate({"id": 1, "x0": 0, "y0": 0, "x1": 1, "y1": 1})
+    assert element.asset_id is None
+
+
+def test_asset_info_visual_elements_expose_asset_id():
+    """asset_id survives when a visual element is parsed as part of an AssetInfo payload."""
+    asset = AssetInfo.model_validate(
+        {
+            "asset_type": AssetType.PAGE_IMAGE,
+            "content_type": "image/png",
+            "presigned_url": "https://example.com/asset",
+            "visual_elements": [
+                {"id": 1, "x0": 72, "y0": 100, "x1": 924, "y1": 215, "asset_id": "asset-1"},
+            ],
+        }
+    )
+    assert asset.visual_elements is not None
+    assert asset.visual_elements[0].asset_id == "asset-1"
 
 
 # ── Client: upload_document with file_data_uuid ──────────────────────────


### PR DESCRIPTION
## What

Adds `asset_id: str | None = None` to `VisualElement` (`cohere_compass/models/search.py`) and bumps the package `2.14.0 → 2.15.0`.

## Why

North (and the Compass MCP) intermittently fetch the wrong figure because the model passes the per-page `visual_element.id` (a small integer that restarts at 1 each page) where an asset UUID is expected. The companion Compass API change denormalizes each visual element's owning `asset_id` onto the element row itself, so the id and coordinates the model reads live in one place.

For that to reach the model, the field has to survive SDK parsing: MCP and North consume these SDK models directly, and pydantic drops unknown fields. Adding `asset_id` here lets the value flow through unchanged.

The field is optional and defaults to `None` so responses from older Compass servers (which don't emit it) still parse.

## Tests

`tests/test_compass_client.py`:
- `test_visual_element_carries_asset_id` — asset_id present is preserved.
- `test_visual_element_asset_id_defaults_to_none_when_absent` — omitted asset_id stays None (backward compatible).
- `test_asset_info_visual_elements_expose_asset_id` — survives when nested in an `AssetInfo` payload.

## Related

[Companion change](https://github.com/cohere-ai/compass/pull/2972) on Compass branch (API denormalization). MCP PR to follow (surfaces the field + fixes the model-facing tool guidance).