### PR TITLE
fix: surface parser errors on CompassDocument in sync client

### DIFF
--- a/cohere_compass/clients/parser.py
+++ b/cohere_compass/clients/parser.py
@@ -379,10 +379,9 @@ class CompassParserClient:
         for doc in res.json()["docs"]:
             if doc.get("errors"):
                 logger.error(f"Error processing file {filename}: {doc['errors']}")
-            else:
-                compass_doc = CompassDocument.adapt_doc_id_compass_doc(doc)
-                additional_metadata = CompassParserClient._get_metadata(doc=compass_doc, custom_context=custom_context)
-                compass_doc.content = {**compass_doc.content, **additional_metadata}
-                docs.append(compass_doc)
+            compass_doc = CompassDocument.adapt_doc_id_compass_doc(doc)
+            additional_metadata = CompassParserClient._get_metadata(doc=compass_doc, custom_context=custom_context)
+            compass_doc.content = {**compass_doc.content, **additional_metadata}
+            docs.append(compass_doc)
 
         return docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.15.0"
+version = "2.15.1"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Sync `CompassParserClient` previously logged parser errors and **skipped** returning those docs, so callers (e.g. North sync `process_file` → `put_documents`) got an empty list and raised a generic `CompassNoContentParsedError` with no details.
- Align with [async parser](https://github.com/cohere-ai/cohere-compass-sdk/blob/f8c46703465fc888c95c00c55337df75d125a3f6/cohere_compass/clients/parser_async.py#L372), which already adapts and returns `CompassDocument`s that carry `errors`.
- Safe for current North callers: [North already filters out docs with `errors`](https://github.com/cohere-ai/north/blob/main/src/backend/services/compass.py#L495-L504) before inserting, so returning errored docs does not change what lands in their list today — it only makes the error message available for them to surface.
- Related to [CMPS-941](https://linear.app/cohereai/issue/CMPS-941/show-a-useful-error-for-password-protected-files-in-compass) (one of several PRs; does not fully address the issue).
- Context: [Password protected file parsing error handling investigation](https://app.notion.com/p/cohereai/Password-protected-file-parsing-error-handling-investigation-3a34398375db80478db6e061457df437)

## Test plan

(I pointed a local North to local compass SDK and made sure this work with it)

- [x] Process a password-protected PDF via sync `process_file` / `process_file_bytes` and confirm the returned `CompassDocument` includes the parsing error (not an empty list).
- [x] Confirm successful parses still return docs unchanged.
- [x] Smoke-check North sync upload path can read `doc.errors` instead of treating the result as “no content.”