### PR TITLE
feat: Compass advertises supported file types

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -64,7 +64,7 @@ from cohere_compass.models import (
     UploadDocumentsInput,
     UploadDocumentsResult,
 )
-from cohere_compass.models.config import IndexConfig
+from cohere_compass.models.config import IndexConfig, SupportedFileTypesResponse
 from cohere_compass.models.documents import (
     AssetPresignedUrlDetails,
     AssetPresignedUrlRequest,
@@ -128,6 +128,10 @@ API_DEFINITIONS = {
     "get_models": (
         "GET",
         "config/models",
+    ),
+    "get_supported_file_types": (
+        "GET",
+        "config/supported-file-types",
     ),
     # Index APIs
     "create_index": (
@@ -388,6 +392,42 @@ class CompassClient:
             raise ValueError("Invalid response from Compass API")
 
         return result.result
+
+    def get_supported_file_types(
+        self,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SupportedFileTypesResponse:
+        """
+        Get the file types Compass can currently parse and index.
+
+        The result depends on the deployment's runtime configuration, so it describes
+        what this Compass deployment accepts rather than a fixed capability list.
+
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        :return: The supported file types, pairing accepted MIME types with the file
+            extensions that map to them.
+
+        :raises CompassClientError: With code 404 against Compass deployments that
+            predate this endpoint.
+        """
+        result = self._send_request(
+            api_name="get_supported_file_types",
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        if not isinstance(result.result, dict):
+            raise ValueError("Invalid response from Compass API")
+
+        return SupportedFileTypesResponse.model_validate(result.result)
 
     def create_index(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -64,7 +64,7 @@ from cohere_compass.models import (
     SearchInput,
     UploadDocumentsInput,
 )
-from cohere_compass.models.config import IndexConfig
+from cohere_compass.models.config import IndexConfig, SupportedFileTypesResponse
 from cohere_compass.models.documents import (
     AssetPresignedUrlDetails,
     AssetPresignedUrlRequest,
@@ -209,6 +209,42 @@ class CompassAsyncClient:
             raise ValueError("Invalid response from Compass API")
 
         return result.result
+
+    async def get_supported_file_types(
+        self,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> SupportedFileTypesResponse:
+        """
+        Get the file types Compass can currently parse and index.
+
+        The result depends on the deployment's runtime configuration, so it describes
+        what this Compass deployment accepts rather than a fixed capability list.
+
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        :return: The supported file types, pairing accepted MIME types with the file
+            extensions that map to them.
+
+        :raises CompassClientError: With code 404 against Compass deployments that
+            predate this endpoint.
+        """
+        result = await self._send_request(
+            api_name="get_supported_file_types",
+            max_retries=max_retries,
+            retry_wait=retry_wait,
+            timeout=timeout,
+        )
+        if not isinstance(result.result, dict):
+            raise ValueError("Invalid response from Compass API")
+
+        return SupportedFileTypesResponse.model_validate(result.result)
 
     async def create_index(
         self,

--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -3,6 +3,7 @@
 # Python imports
 import math
 from enum import Enum
+from pathlib import PurePosixPath
 from typing import Annotated, Any, Literal
 
 # 3rd party imports
@@ -215,3 +216,82 @@ class IndexConfig(BaseModel):
     analyzer: str | None = None
     dense_model: str | None = None
     sparse_model: str | None = None
+
+
+class SupportedFileType(BaseModel):
+    """
+    One file format Compass accepts, as a set of MIME types and matching extensions.
+
+    MIME types are modelled as plain strings rather than ContentTypeEnum so that a
+    Compass deployment newer than the SDK can advertise types the SDK does not know
+    about yet without failing validation.
+
+    :param mime_types: MIME types accepted for this format, canonical type first
+        followed by any aliases that resolve to the same extensions.
+    :param extensions: File extensions for this format, lowercase and dot-prefixed.
+        Empty for formats uploaded by MIME type only, such as application/octet-stream.
+    """
+
+    mime_types: list[str] = Field(
+        default_factory=list,
+        description="MIME types accepted for this format: canonical type first, then aliases.",
+    )
+    extensions: list[str] = Field(
+        default_factory=list,
+        description="File extensions (with leading dot) for this format. Empty for MIME-only formats.",
+    )
+
+
+class SupportedFileTypesResponse(BaseModel):
+    """
+    The file formats a Compass deployment can currently parse and index.
+
+    The set is gated by the deployment's runtime configuration rather than being a
+    static capability list: audio formats are advertised only when ASR is enabled, and
+    video formats additionally require the video LLM. Query it per deployment instead
+    of caching it across environments.
+
+    :param file_types: The supported formats, each pairing MIME types with extensions.
+    """
+
+    file_types: list[SupportedFileType] = Field(
+        default_factory=list[SupportedFileType],
+        description="Supported formats, each pairing accepted MIME types with their file extensions.",
+    )
+
+    @property
+    def mime_types(self) -> set[str]:
+        """All accepted MIME types, flattened across formats."""
+        return {mime_type for file_type in self.file_types for mime_type in file_type.mime_types}
+
+    @property
+    def extensions(self) -> set[str]:
+        """All accepted file extensions, flattened across formats."""
+        return {extension for file_type in self.file_types for extension in file_type.extensions}
+
+    def supports(self, *, filename: str | None = None, mime_type: str | None = None) -> bool:
+        """
+        Check whether Compass accepts a file identified by its name and/or MIME type.
+
+        When both arguments are given the file counts as supported if either one
+        matches, since Compass can accept an upload on the strength of either signal.
+        Prefer passing the MIME type when you have a trustworthy one, as that is what
+        Compass validates at upload time. Callers needing to know which signal matched
+        should test :attr:`mime_types` and :attr:`extensions` directly.
+
+        :param filename: File name to check. Only its extension is used, matched
+            case-insensitively.
+        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
+            parameters such as "; charset=utf-8".
+
+        :return: True if Compass accepts the file, False otherwise.
+
+        :raises ValueError: If neither filename nor mime_type is provided.
+        """
+        if filename is None and mime_type is None:
+            raise ValueError("At least one of filename or mime_type must be provided.")
+
+        if mime_type is not None and mime_type.split(";")[0].strip().lower() in self.mime_types:
+            return True
+
+        return filename is not None and PurePosixPath(filename).suffix.lower() in self.extensions

--- a/examples/compass_sdk_examples/get_supported_file_types.py
+++ b/examples/compass_sdk_examples/get_supported_file_types.py
@@ -1,0 +1,36 @@
+from cohere_compass.models import SupportedFileTypesResponse
+
+from compass_sdk_examples.utils import get_compass_client, get_compass_client_async
+
+
+def print_supported_file_types(supported: SupportedFileTypesResponse) -> None:
+    print("Supported file types:")
+    for file_type in supported.file_types:
+        extensions = ", ".join(file_type.extensions) or "(no extensions)"
+        print(f"  {extensions}: {', '.join(file_type.mime_types)}")
+
+
+def main():
+    client = get_compass_client()
+
+    supported = client.get_supported_file_types()
+    print_supported_file_types(supported)
+
+    # The supported set depends on the deployment's runtime configuration, so audio
+    # only appears when ASR is enabled on the Compass being queried.
+    print(f"\nreport.pdf supported? {supported.supports(filename='report.pdf')}")
+    print(f"podcast.mp3 supported? {supported.supports(filename='podcast.mp3')}")
+
+
+async def main_async():
+    client = get_compass_client_async()
+
+    print_supported_file_types(await client.get_supported_file_types())
+
+
+if __name__ == "__main__":
+    main()
+
+    # Or use the async version...
+    # import asyncio
+    # asyncio.run(main_async())

--- a/examples/fern_documentation/python/core/get_supported_file_types.py
+++ b/examples/fern_documentation/python/core/get_supported_file_types.py
@@ -1,0 +1,18 @@
+from cohere_compass.clients.compass import CompassClient
+from cohere_compass.exceptions import CompassError
+
+COMPASS_API_URL = "<COMPASS_API_URL>"
+BEARER_TOKEN = "<BEARER_TOKEN>"
+
+client = CompassClient(index_url=COMPASS_API_URL, bearer_token=BEARER_TOKEN)
+try:
+    supported = client.get_supported_file_types()
+    print("Supported file types:")
+    for file_type in supported.file_types:
+        extensions = ", ".join(file_type.extensions) or "(no extensions)"
+        mime_types = ", ".join(file_type.mime_types)
+        print(f"Extensions: {extensions}, MIME types: {mime_types}")
+
+    print(f"report.pdf supported? {supported.supports(filename='report.pdf')}")
+except CompassError as e:
+    print(f"Error fetching supported file types: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.15.1"
+version = "2.16.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -21,7 +21,11 @@ from cohere_compass.models import (
     CompassDocument,
     SearchFilter,
 )
-from cohere_compass.models.config import IndexConfig
+from cohere_compass.models.config import (
+    IndexConfig,
+    SupportedFileType,
+    SupportedFileTypesResponse,
+)
 from cohere_compass.models.documents import (
     AssetPresignedUrlRequest,
     AssetType,
@@ -544,6 +548,72 @@ def test_get_models(client: CompassClient, respx_mock: MockRouter):
             "rerank-v3.5",
         ],
     }
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    200,
+    response_body={
+        "file_types": [
+            {"mime_types": ["application/pdf"], "extensions": [".pdf"]},
+            {"mime_types": ["text/html"], "extensions": [".htm", ".html"]},
+            {"mime_types": ["application/octet-stream"], "extensions": []},
+        ]
+    },
+)
+def test_get_supported_file_types_returns_parsed_response(client: CompassClient):
+    """Each advertised format is parsed into a SupportedFileType with its MIME types and extensions."""
+    result = client.get_supported_file_types()
+
+    assert result == SupportedFileTypesResponse(
+        file_types=[
+            SupportedFileType(mime_types=["application/pdf"], extensions=[".pdf"]),
+            SupportedFileType(mime_types=["text/html"], extensions=[".htm", ".html"]),
+            SupportedFileType(mime_types=["application/octet-stream"], extensions=[]),
+        ]
+    )
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    200,
+    response_body={"file_types": [{"mime_types": ["application/x-not-in-sdk-enum"], "extensions": [".weird"]}]},
+)
+def test_get_supported_file_types_accepts_mime_types_unknown_to_the_sdk(client: CompassClient):
+    """A newer deployment advertising a MIME type the SDK's ContentTypeEnum lacks must still parse."""
+    result = client.get_supported_file_types()
+
+    assert result.mime_types == {"application/x-not-in-sdk-enum"}
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    200,
+    response_body={"file_types": []},
+)
+def test_get_supported_file_types_handles_empty_file_types(client: CompassClient):
+    """A deployment advertising nothing yields an empty response rather than an error."""
+    result = client.get_supported_file_types()
+
+    assert result.file_types == []
+    assert result.mime_types == set()
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    404,
+    response_body={"detail": "Not Found"},
+)
+def test_get_supported_file_types_raises_client_error_on_older_deployment(client: CompassClient):
+    """Deployments predating the endpoint return 404, which must surface as a catchable CompassClientError."""
+    with pytest.raises(CompassClientError) as exc_info:
+        client.get_supported_file_types()
+
+    assert exc_info.value.code == 404
 
 
 @respx.mock

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,124 @@
+import pytest
+
+from cohere_compass.models.config import SupportedFileType, SupportedFileTypesResponse
+
+
+@pytest.fixture
+def supported_file_types() -> SupportedFileTypesResponse:
+    """A response covering an alias group, a multi-extension format, and a MIME-only format."""
+    return SupportedFileTypesResponse(
+        file_types=[
+            SupportedFileType(mime_types=["application/pdf"], extensions=[".pdf"]),
+            SupportedFileType(mime_types=["text/html"], extensions=[".htm", ".html"]),
+            SupportedFileType(mime_types=["audio/mpeg", "audio/mp3"], extensions=[".mp3"]),
+            SupportedFileType(mime_types=["application/octet-stream"], extensions=[]),
+        ]
+    )
+
+
+def test_mime_types_flattens_every_format_including_aliases(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Aliases are surfaced alongside canonical types so callers can match either."""
+    assert supported_file_types.mime_types == {
+        "application/pdf",
+        "text/html",
+        "audio/mpeg",
+        "audio/mp3",
+        "application/octet-stream",
+    }
+
+
+def test_extensions_flattens_every_format_and_omits_mime_only_formats(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Formats with no extensions contribute nothing rather than an empty string entry."""
+    assert supported_file_types.extensions == {".pdf", ".htm", ".html", ".mp3"}
+
+
+def test_supports_matching_extension_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
+    """A filename whose extension maps to an advertised format is supported."""
+    assert supported_file_types.supports(filename="quarterly-report.pdf") is True
+
+
+def test_supports_uppercase_extension_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
+    """Extension matching is case-insensitive, since the server advertises lowercase only."""
+    assert supported_file_types.supports(filename="QUARTERLY-REPORT.PDF") is True
+
+
+def test_supports_extension_on_path_like_filename_returns_true(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Only the final suffix is considered, so full paths from connectors work unchanged."""
+    assert supported_file_types.supports(filename="/shared/docs/report.pdf") is True
+
+
+def test_supports_unknown_extension_returns_false(supported_file_types: SupportedFileTypesResponse) -> None:
+    """An extension no advertised format claims is unsupported."""
+    assert supported_file_types.supports(filename="archive.zip") is False
+
+
+def test_supports_filename_without_extension_returns_false(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """An empty suffix must not accidentally match a format that advertises no extensions."""
+    assert supported_file_types.supports(filename="README") is False
+
+
+def test_supports_matching_mime_type_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
+    """A MIME type advertised by any format is supported."""
+    assert supported_file_types.supports(mime_type="application/pdf") is True
+
+
+def test_supports_alias_mime_type_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
+    """Alias MIME types are accepted, not just the canonical type of each format."""
+    assert supported_file_types.supports(mime_type="audio/mp3") is True
+
+
+def test_supports_mime_type_with_parameters_returns_true(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Content-Type parameters such as charset are stripped before matching."""
+    assert supported_file_types.supports(mime_type="text/html; charset=utf-8") is True
+
+
+def test_supports_uppercase_mime_type_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
+    """MIME matching is case-insensitive, as MIME types are case-insensitive per RFC 2045."""
+    assert supported_file_types.supports(mime_type="Application/PDF") is True
+
+
+def test_supports_mime_only_format_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
+    """Formats advertised without extensions are still matchable by MIME type."""
+    assert supported_file_types.supports(mime_type="application/octet-stream") is True
+
+
+def test_supports_unknown_mime_type_returns_false(supported_file_types: SupportedFileTypesResponse) -> None:
+    """A MIME type no format advertises is unsupported."""
+    assert supported_file_types.supports(mime_type="application/zip") is False
+
+
+def test_supports_returns_true_when_only_one_of_two_signals_matches(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Either signal matching is enough, so a generic MIME type does not veto a known extension."""
+    assert supported_file_types.supports(filename="report.pdf", mime_type="application/zip") is True
+
+
+def test_supports_returns_false_when_neither_signal_matches(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Both signals failing means the file is unsupported."""
+    assert supported_file_types.supports(filename="archive.zip", mime_type="application/zip") is False
+
+
+def test_supports_without_arguments_raises_value_error(
+    supported_file_types: SupportedFileTypesResponse,
+) -> None:
+    """Calling with no identifiers is a programming error rather than a silent False."""
+    with pytest.raises(ValueError, match="At least one of filename or mime_type"):
+        supported_file_types.supports()
+
+
+def test_supports_on_empty_response_returns_false() -> None:
+    """A deployment advertising nothing supports nothing."""
+    assert SupportedFileTypesResponse().supports(filename="report.pdf") is False


### PR DESCRIPTION
Supporting a new API endpoint for advertising what file types a specific install supports