### PR TITLE
feat: manage supported file types baseline from Compass SDK.

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -42,10 +42,14 @@ from cohere_compass.constants import (
     DEFAULT_RETRY_WAIT,
     URL_SAFE_STRING_PATTERN,
 )
+from cohere_compass.content_types import BASELINE_SUPPORTED_FILE_TYPES
 from cohere_compass.exceptions import (
+    CompassClientError,
     CompassError,
     CompassInsertionError,
     CompassMaxErrorRateExceeded,
+    CompassNetworkError,
+    CompassServerError,
     handle_httpx_exceptions,
 )
 from cohere_compass.models import (
@@ -334,6 +338,7 @@ class CompassClient:
         self.httpx = httpx_client or httpx.Client(timeout=self.timeout.total_seconds())
         self._own_httpx_client = httpx_client is None
         self._closed = False
+        self._supported_file_types: SupportedFileTypesResponse | None = None
 
         self.bearer_token = bearer_token
 
@@ -395,16 +400,24 @@ class CompassClient:
 
     def get_supported_file_types(
         self,
+        fallback_on_failure: bool = True,
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
     ) -> SupportedFileTypesResponse:
         """
-        Get the file types Compass can currently parse and index.
+        Get the file types this Compass deployment can parse and index.
 
-        The result depends on the deployment's runtime configuration, so it describes
-        what this Compass deployment accepts rather than a fixed capability list.
+        The result depends on the deployment's configuration, so it describes what this
+        deployment accepts rather than a fixed capability list. The response is not
+        cached; each call queries the deployment.
 
+        :param fallback_on_failure: When True, return
+            :data:`cohere_compass.content_types.BASELINE_SUPPORTED_FILE_TYPES` instead of
+            raising if the deployment cannot answer, meaning it is unreachable, returned a
+            server error, or predates this endpoint. Authentication and other client
+            errors always raise, since those indicate a problem with the request rather
+            than with the deployment.
         :param max_retries: Maximum number of retries for failed requests. If not
             provided, the default from the client will be used.
         :param retry_wait: Time to wait between retries. If not provided, the default
@@ -416,18 +429,84 @@ class CompassClient:
             extensions that map to them.
 
         :raises CompassClientError: With code 404 against Compass deployments that
-            predate this endpoint.
+            predate this endpoint, unless fallback_on_failure is True.
         """
-        result = self._send_request(
-            api_name="get_supported_file_types",
-            max_retries=max_retries,
-            retry_wait=retry_wait,
-            timeout=timeout,
-        )
+        try:
+            result = self._send_request(
+                api_name="get_supported_file_types",
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+            )
+        except (CompassNetworkError, CompassServerError):
+            if not fallback_on_failure:
+                raise
+            return BASELINE_SUPPORTED_FILE_TYPES
+        except CompassClientError as exc:
+            if not fallback_on_failure or exc.code != 404:
+                raise
+            return BASELINE_SUPPORTED_FILE_TYPES
+
         if not isinstance(result.result, dict):
             raise ValueError("Invalid response from Compass API")
 
         return SupportedFileTypesResponse.model_validate(result.result)
+
+    def is_file_type_supported(
+        self,
+        *,
+        filename: str | None = None,
+        mime_type: str | None = None,
+        fallback_on_failure: bool = True,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> bool:
+        """
+        Check whether this Compass deployment accepts a file.
+
+        Answers from :data:`cohere_compass.content_types.BASELINE_SUPPORTED_FILE_TYPES`
+        first, and only queries the deployment for file types outside that set. The
+        deployment's answer is then reused for the lifetime of this client, so a
+        long-running process makes at most one request. Call
+        :meth:`get_supported_file_types` instead when you need a current answer.
+
+        :param filename: File name to check. Only its extension is used, matched
+            case-insensitively.
+        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
+            parameters such as "; charset=utf-8".
+        :param fallback_on_failure: When True, a deployment that cannot answer yields
+            False for file types outside the baseline, rather than raising. False is the
+            safe answer here: it reports a file as unsupported rather than accepting one
+            the deployment may reject.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        :return: True if the deployment accepts the file, False otherwise.
+
+        :raises ValueError: If neither filename nor mime_type is provided.
+        """
+        if BASELINE_SUPPORTED_FILE_TYPES.supports(filename=filename, mime_type=mime_type):
+            return True
+
+        if self._supported_file_types is None:
+            fetched = self.get_supported_file_types(
+                fallback_on_failure=fallback_on_failure,
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+            )
+            # The baseline is returned only when the deployment could not answer. Caching
+            # it would make one failed request permanently narrow this client's answers.
+            if fetched is BASELINE_SUPPORTED_FILE_TYPES:
+                return False
+            self._supported_file_types = fetched
+
+        return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 
     def create_index(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -43,10 +43,14 @@ from cohere_compass.constants import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_RETRY_WAIT,
 )
+from cohere_compass.content_types import BASELINE_SUPPORTED_FILE_TYPES
 from cohere_compass.exceptions import (
+    CompassClientError,
     CompassError,
     CompassInsertionError,
     CompassMaxErrorRateExceeded,
+    CompassNetworkError,
+    CompassServerError,
     handle_httpx_exceptions,
 )
 from cohere_compass.models import (
@@ -148,6 +152,7 @@ class CompassAsyncClient:
         self.httpx = httpx_client or httpx.AsyncClient(timeout=self.timeout.total_seconds())
         self._own_httpx_client = httpx_client is None
         self._closed = False
+        self._supported_file_types: SupportedFileTypesResponse | None = None
 
         self.bearer_token = bearer_token
 
@@ -212,16 +217,24 @@ class CompassAsyncClient:
 
     async def get_supported_file_types(
         self,
+        fallback_on_failure: bool = True,
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
     ) -> SupportedFileTypesResponse:
         """
-        Get the file types Compass can currently parse and index.
+        Get the file types this Compass deployment can parse and index.
 
-        The result depends on the deployment's runtime configuration, so it describes
-        what this Compass deployment accepts rather than a fixed capability list.
+        The result depends on the deployment's configuration, so it describes what this
+        deployment accepts rather than a fixed capability list. The response is not
+        cached; each call queries the deployment.
 
+        :param fallback_on_failure: When True, return
+            :data:`cohere_compass.content_types.BASELINE_SUPPORTED_FILE_TYPES` instead of
+            raising if the deployment cannot answer, meaning it is unreachable, returned a
+            server error, or predates this endpoint. Authentication and other client
+            errors always raise, since those indicate a problem with the request rather
+            than with the deployment.
         :param max_retries: Maximum number of retries for failed requests. If not
             provided, the default from the client will be used.
         :param retry_wait: Time to wait between retries. If not provided, the default
@@ -233,18 +246,84 @@ class CompassAsyncClient:
             extensions that map to them.
 
         :raises CompassClientError: With code 404 against Compass deployments that
-            predate this endpoint.
+            predate this endpoint, unless fallback_on_failure is True.
         """
-        result = await self._send_request(
-            api_name="get_supported_file_types",
-            max_retries=max_retries,
-            retry_wait=retry_wait,
-            timeout=timeout,
-        )
+        try:
+            result = await self._send_request(
+                api_name="get_supported_file_types",
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+            )
+        except (CompassNetworkError, CompassServerError):
+            if not fallback_on_failure:
+                raise
+            return BASELINE_SUPPORTED_FILE_TYPES
+        except CompassClientError as exc:
+            if not fallback_on_failure or exc.code != 404:
+                raise
+            return BASELINE_SUPPORTED_FILE_TYPES
+
         if not isinstance(result.result, dict):
             raise ValueError("Invalid response from Compass API")
 
         return SupportedFileTypesResponse.model_validate(result.result)
+
+    async def is_file_type_supported(
+        self,
+        *,
+        filename: str | None = None,
+        mime_type: str | None = None,
+        fallback_on_failure: bool = True,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+    ) -> bool:
+        """
+        Check whether this Compass deployment accepts a file.
+
+        Answers from :data:`cohere_compass.content_types.BASELINE_SUPPORTED_FILE_TYPES`
+        first, and only queries the deployment for file types outside that set. The
+        deployment's answer is then reused for the lifetime of this client, so a
+        long-running process makes at most one request. Call
+        :meth:`get_supported_file_types` instead when you need a current answer.
+
+        :param filename: File name to check. Only its extension is used, matched
+            case-insensitively.
+        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
+            parameters such as "; charset=utf-8".
+        :param fallback_on_failure: When True, a deployment that cannot answer yields
+            False for file types outside the baseline, rather than raising. False is the
+            safe answer here: it reports a file as unsupported rather than accepting one
+            the deployment may reject.
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+
+        :return: True if the deployment accepts the file, False otherwise.
+
+        :raises ValueError: If neither filename nor mime_type is provided.
+        """
+        if BASELINE_SUPPORTED_FILE_TYPES.supports(filename=filename, mime_type=mime_type):
+            return True
+
+        if self._supported_file_types is None:
+            fetched = await self.get_supported_file_types(
+                fallback_on_failure=fallback_on_failure,
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+            )
+            # The baseline is returned only when the deployment could not answer. Caching
+            # it would make one failed request permanently narrow this client's answers.
+            if fetched is BASELINE_SUPPORTED_FILE_TYPES:
+                return False
+            self._supported_file_types = fetched
+
+        return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 
     async def create_index(
         self,

--- a/cohere_compass/content_types.py
+++ b/cohere_compass/content_types.py
@@ -1,0 +1,161 @@
+"""
+The file types Compass accepts, as MIME types and the file extensions that map to them.
+
+:data:`BASELINE_SUPPORTED_FILE_TYPES` is the minimal set: the file types every Compass
+deployment accepts, whatever its configuration. Audio and video are excluded because they
+depend on backends a given deployment may not run. For what a specific deployment
+accepts, call ``CompassClient.get_supported_file_types()``.
+"""
+
+# Python imports
+from collections.abc import Collection
+from enum import Enum
+
+# Local imports
+from cohere_compass.models.config import SupportedFileType, SupportedFileTypesResponse
+from cohere_compass.models.documents import ContentTypeEnum
+
+
+class ParserCapability(str, Enum):
+    """
+    An optional backend a Compass deployment may or may not run.
+
+    A content type listed in :data:`CONTENT_TYPE_REQUIRED_CAPABILITIES` is accepted only
+    by deployments that have every capability it requires.
+    """
+
+    ASR = "asr"
+    VIDEO_LLM = "video_llm"
+
+
+# Content types accepted only by deployments with the listed capabilities. Types absent
+# from this mapping are accepted by every deployment. Video requires ASR as well as the
+# video LLM, because video parsing transcribes the audio track.
+CONTENT_TYPE_REQUIRED_CAPABILITIES: dict[ContentTypeEnum, frozenset[ParserCapability]] = {
+    ContentTypeEnum.AudioMpeg: frozenset({ParserCapability.ASR}),
+    ContentTypeEnum.AudioWav: frozenset({ParserCapability.ASR}),
+    ContentTypeEnum.AudioMp3: frozenset({ParserCapability.ASR}),
+    ContentTypeEnum.VideoMp4: frozenset({ParserCapability.ASR, ParserCapability.VIDEO_LLM}),
+    ContentTypeEnum.VideoXMsVideo: frozenset({ParserCapability.ASR, ParserCapability.VIDEO_LLM}),
+}
+
+
+# File extension -> content type. Each extension maps to exactly one content type, so
+# alias types that share an extension contribute none of their own; the canonical type
+# owns the suffix.
+EXTENSION_TO_CONTENT_TYPE: dict[str, ContentTypeEnum] = {
+    ".txt": ContentTypeEnum.TextPlain,
+    ".html": ContentTypeEnum.TextHtml,
+    ".htm": ContentTypeEnum.TextHtml,
+    ".csv": ContentTypeEnum.TextCsv,
+    ".tsv": ContentTypeEnum.TextTsv,
+    ".tab": ContentTypeEnum.TextTsv,
+    ".md": ContentTypeEnum.TextMarkdown,
+    ".org": ContentTypeEnum.TextOrg,
+    ".rst": ContentTypeEnum.TextRst,
+    ".json": ContentTypeEnum.ApplicationJson,
+    ".jsonl": ContentTypeEnum.ApplicationJsonl,
+    ".pdf": ContentTypeEnum.ApplicationPdf,
+    ".xml": ContentTypeEnum.ApplicationXml,
+    ".doc": ContentTypeEnum.ApplicationMsword,
+    ".docx": ContentTypeEnum.ApplicationVndOpenXMLDocument,
+    ".xls": ContentTypeEnum.ApplicationVndMsExcel,
+    ".xlsx": ContentTypeEnum.ApplicationVndOpenXMLSpreadsheet,
+    ".xlsm": ContentTypeEnum.ApplicationVndMsExcelSheetMacroEnabled,
+    ".xltx": ContentTypeEnum.ApplicationVndOpenXMLSpreadsheetTemplate,
+    ".xltm": ContentTypeEnum.ApplicationVndMsExcelTemplateMacroEnabled,
+    ".ppt": ContentTypeEnum.ApplicationVndMsPowerpoint,
+    ".pptx": ContentTypeEnum.ApplicationVndOpenXMLPresentation,
+    ".epub": ContentTypeEnum.ApplicationEpubZip,
+    ".odt": ContentTypeEnum.ApplicationVndOasisOpenDocumentText,
+    ".ods": ContentTypeEnum.ApplicationVndOasisOpenDocumentSpreadsheet,
+    ".odp": ContentTypeEnum.ApplicationVndOasisOpenDocumentPresentation,
+    ".msg": ContentTypeEnum.ApplicationMsOutlook,
+    ".rtf": ContentTypeEnum.ApplicationRtf,
+    ".yaml": ContentTypeEnum.ApplicationYaml,
+    ".yml": ContentTypeEnum.ApplicationYaml,
+    ".hwp": ContentTypeEnum.ApplicationXHwp,
+    ".hwpx": ContentTypeEnum.ApplicationXHwpx,
+    ".jpg": ContentTypeEnum.ImageJpeg,
+    ".jpeg": ContentTypeEnum.ImageJpeg,
+    ".png": ContentTypeEnum.ImagePng,
+    ".heic": ContentTypeEnum.ImageHeic,
+    ".tiff": ContentTypeEnum.ImageTiff,
+    ".bmp": ContentTypeEnum.ImageBmp,
+    ".gif": ContentTypeEnum.ImageGif,
+    ".svg": ContentTypeEnum.ImageSvgXml,
+    ".webp": ContentTypeEnum.ImageWebp,
+    ".mp3": ContentTypeEnum.AudioMpeg,
+    ".wav": ContentTypeEnum.AudioWav,
+    ".mp4": ContentTypeEnum.VideoMp4,
+    ".avi": ContentTypeEnum.VideoXMsVideo,
+    ".eml": ContentTypeEnum.MessageRfc822,
+}
+
+
+# Alias content type -> canonical content type. Aliases are accepted on upload and share
+# the canonical type's extensions.
+CONTENT_TYPE_ALIASES: dict[ContentTypeEnum, ContentTypeEnum] = {
+    ContentTypeEnum.ApplicationJsonLines: ContentTypeEnum.ApplicationJsonl,
+    ContentTypeEnum.AudioMp3: ContentTypeEnum.AudioMpeg,
+    ContentTypeEnum.TextXMarkdown: ContentTypeEnum.TextMarkdown,
+    ContentTypeEnum.ApplicationMarkdown: ContentTypeEnum.TextMarkdown,
+    ContentTypeEnum.ApplicationXMarkdown: ContentTypeEnum.TextMarkdown,
+    ContentTypeEnum.ImageJpg: ContentTypeEnum.ImageJpeg,
+    ContentTypeEnum.ApplicationXlsx: ContentTypeEnum.ApplicationVndOpenXMLSpreadsheet,
+    ContentTypeEnum.ApplicationXYaml: ContentTypeEnum.ApplicationYaml,
+    ContentTypeEnum.TextYaml: ContentTypeEnum.ApplicationYaml,
+    ContentTypeEnum.TextXYaml: ContentTypeEnum.ApplicationYaml,
+}
+
+
+def _derive_content_type_to_extensions() -> dict[ContentTypeEnum, list[str]]:
+    mapping: dict[ContentTypeEnum, list[str]] = {ct: [] for ct in ContentTypeEnum}
+    for extension, content_type in EXTENSION_TO_CONTENT_TYPE.items():
+        mapping[content_type].append(extension)
+    for extensions in mapping.values():
+        extensions.sort()
+    return mapping
+
+
+# Content type -> its sorted file extensions, derived from EXTENSION_TO_CONTENT_TYPE so
+# the two directions cannot disagree. Empty for types uploaded by MIME type only.
+CONTENT_TYPE_TO_EXTENSIONS: dict[ContentTypeEnum, list[str]] = _derive_content_type_to_extensions()
+
+
+def _supported_content_types(available_capabilities: Collection[ParserCapability]) -> list[ContentTypeEnum]:
+    available = frozenset(available_capabilities)
+    return [ct for ct in ContentTypeEnum if CONTENT_TYPE_REQUIRED_CAPABILITIES.get(ct, frozenset()) <= available]
+
+
+def resolve_supported_file_types(content_types: Collection[ContentTypeEnum]) -> list[SupportedFileType]:
+    """
+    Group content types by canonical type, pairing each with its aliases and extensions.
+
+    An alias appears only when it is itself in ``content_types``, so the result never
+    lists a MIME type the caller did not accept.
+
+    :param content_types: The accepted content types.
+
+    :return: One entry per accepted non-alias content type, each listing its canonical
+        MIME type first, then its accepted aliases.
+    """
+    supported = set(content_types)
+    aliases_by_canonical: dict[ContentTypeEnum, list[ContentTypeEnum]] = {}
+    for alias, canonical in CONTENT_TYPE_ALIASES.items():
+        aliases_by_canonical.setdefault(canonical, []).append(alias)
+
+    resolved: list[SupportedFileType] = []
+    for ct in ContentTypeEnum:
+        if ct in CONTENT_TYPE_ALIASES or ct not in supported:
+            continue
+        mime_types = [ct.value] + [a.value for a in sorted(aliases_by_canonical.get(ct, [])) if a in supported]
+        resolved.append(SupportedFileType(mime_types=mime_types, extensions=CONTENT_TYPE_TO_EXTENSIONS[ct]))
+    return resolved
+
+
+# The file types every Compass deployment accepts, whatever its configuration. Treat as
+# read-only: it is shared across the process, so mutating it affects every caller.
+BASELINE_SUPPORTED_FILE_TYPES: SupportedFileTypesResponse = SupportedFileTypesResponse(
+    file_types=resolve_supported_file_types(_supported_content_types(frozenset())),
+)

--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -291,7 +291,9 @@ class SupportedFileTypesResponse(BaseModel):
         if filename is None and mime_type is None:
             raise ValueError("At least one of filename or mime_type must be provided.")
 
-        if mime_type is not None and mime_type.split(";")[0].strip().lower() in self.mime_types:
-            return True
+        if mime_type is not None:
+            queried = mime_type.split(";")[0].strip().lower()
+            if any(queried == advertised.lower() for advertised in self.mime_types):
+                return True
 
         return filename is not None and PurePosixPath(filename).suffix.lower() in self.extensions

--- a/cohere_compass/models/documents.py
+++ b/cohere_compass/models/documents.py
@@ -467,6 +467,7 @@ class ContentTypeEnum(str, Enum):
     TextCsv = "text/csv"
     TextTsv = "text/tab-separated-values"
     TextMarkdown = "text/markdown"
+    TextXMarkdown = "text/x-markdown"
     TextOrg = "text/org"
     TextRst = "text/prs.fallenstein.rst"
 
@@ -475,11 +476,19 @@ class ContentTypeEnum(str, Enum):
     ApplicationJsonl = "application/jsonl"
     ApplicationJsonLines = "application/json-lines"
     ApplicationPdf = "application/pdf"
+    ApplicationMarkdown = "application/markdown"
+    ApplicationXMarkdown = "application/x-markdown"
     ApplicationXml = "application/xml"
     ApplicationMsword = "application/msword"
     ApplicationVndOpenXMLDocument = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     ApplicationVndMsExcel = "application/vnd.ms-excel"
     ApplicationVndOpenXMLSpreadsheet = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    # Macro-enabled / template OOXML spreadsheet variants (distinct suffixes).
+    ApplicationVndMsExcelSheetMacroEnabled = "application/vnd.ms-excel.sheet.macroEnabled.12"
+    ApplicationVndMsExcelTemplateMacroEnabled = "application/vnd.ms-excel.template.macroEnabled.12"
+    ApplicationVndOpenXMLSpreadsheetTemplate = "application/vnd.openxmlformats-officedocument.spreadsheetml.template"
+    # Nonstandard alias seen in the wild; folds to the .xlsx canonical type.
+    ApplicationXlsx = "application/xlsx"
     ApplicationVndMsPowerpoint = "application/vnd.ms-powerpoint"
     ApplicationVndOpenXMLPresentation = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     ApplicationEpubZip = "application/epub+zip"
@@ -490,12 +499,20 @@ class ContentTypeEnum(str, Enum):
     ApplicationMsOutlook = "application/vnd.ms-outlook"
     ApplicationOctetStream = "application/octet-stream"
     ApplicationRtf = "application/rtf"
+    ApplicationYaml = "application/yaml"
+    ApplicationXYaml = "application/x-yaml"
+    TextYaml = "text/yaml"
+    TextXYaml = "text/x-yaml"
+    # Serialization of a parser-package CompassDocument. Uploading content with this
+    # MIME type signals "do not parse": the bytes are embedded and indexed unchanged.
+    ApplicationVndCohereCompassV1Json = "application/vnd.cohere.compassV1+json"
     # HWP types
     ApplicationXHwp = "application/x-hwp"
     ApplicationXHwpx = "application/x-hwpx"
 
     # Image types
     ImageJpeg = "image/jpeg"
+    ImageJpg = "image/jpg"
     ImagePng = "image/png"
     ImageHeic = "image/heic"
     ImageTiff = "image/tiff"

--- a/examples/compass_sdk_examples/get_supported_file_types.py
+++ b/examples/compass_sdk_examples/get_supported_file_types.py
@@ -21,6 +21,11 @@ def main():
     print(f"\nreport.pdf supported? {supported.supports(filename='report.pdf')}")
     print(f"podcast.mp3 supported? {supported.supports(filename='podcast.mp3')}")
 
+    # Or let the client answer. It checks the baseline every deployment accepts
+    # before querying, then reuses the deployment's answer for later calls.
+    print(f"\nreport.pdf? {client.is_file_type_supported(filename='report.pdf')}")
+    print(f"podcast.mp3? {client.is_file_type_supported(filename='podcast.mp3')}")
+
 
 async def main_async():
     client = get_compass_client_async()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.16.0"
+version = "2.17.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -11,10 +11,12 @@ from respx import MockRouter
 
 from cohere_compass import GroupAuthorizationActions, GroupAuthorizationInput
 from cohere_compass.clients import CompassClient
+from cohere_compass.content_types import BASELINE_SUPPORTED_FILE_TYPES
 from cohere_compass.exceptions import (
     CompassAuthError,
     CompassClientError,
     CompassError,
+    CompassNetworkError,
     CompassTimeoutError,
 )
 from cohere_compass.models import (
@@ -608,12 +610,147 @@ def test_get_supported_file_types_handles_empty_file_types(client: CompassClient
     404,
     response_body={"detail": "Not Found"},
 )
-def test_get_supported_file_types_raises_client_error_on_older_deployment(client: CompassClient):
-    """Deployments predating the endpoint return 404, which must surface as a catchable CompassClientError."""
+def test_get_supported_file_types_raises_client_error_on_older_deployment_without_fallback(client: CompassClient):
+    """Deployments predating the endpoint return 404, which must surface when fallback is declined."""
+    with pytest.raises(CompassClientError) as exc_info:
+        client.get_supported_file_types(fallback_on_failure=False)
+
+    assert exc_info.value.code == 404
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    404,
+    response_body={"detail": "Not Found"},
+)
+def test_get_supported_file_types_falls_back_to_baseline_on_older_deployment(client: CompassClient):
+    """A deployment predating the endpoint yields the baseline, not an error, by default."""
+    assert client.get_supported_file_types() is BASELINE_SUPPORTED_FILE_TYPES
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    401,
+    response_body={"detail": "Unauthorized"},
+)
+def test_get_supported_file_types_raises_on_auth_error_despite_fallback(client: CompassClient):
+    """A bad token is a caller problem, so it must surface rather than degrade to the baseline."""
+    with pytest.raises(CompassAuthError):
+        client.get_supported_file_types()
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    400,
+    response_body={"detail": "Bad Request"},
+)
+def test_get_supported_file_types_raises_on_other_client_errors_despite_fallback(client: CompassClient):
+    """Only 404 means "this deployment has no such endpoint"; other 4xx indicate a bad request."""
     with pytest.raises(CompassClientError) as exc_info:
         client.get_supported_file_types()
 
-    assert exc_info.value.code == 404
+    assert exc_info.value.code == 400
+
+
+@respx.mock
+def test_get_supported_file_types_falls_back_to_baseline_on_server_error(client: CompassClient, respx_mock: MockRouter):
+    """A deployment that is up but erroring cannot answer, so the baseline applies."""
+    respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
+        return_value=httpx.Response(503, json={"detail": "Service Unavailable"})
+    )
+
+    assert client.get_supported_file_types(max_retries=1) is BASELINE_SUPPORTED_FILE_TYPES
+
+
+@respx.mock
+def test_get_supported_file_types_falls_back_to_baseline_when_unreachable(
+    client: CompassClient, respx_mock: MockRouter
+):
+    """An unreachable deployment is the case the baseline exists for."""
+    respx_mock.get("http://test.com/v1/config/supported-file-types").mock(side_effect=httpx.ConnectError("no route"))
+
+    assert client.get_supported_file_types(max_retries=1) is BASELINE_SUPPORTED_FILE_TYPES
+
+
+@respx.mock
+def test_get_supported_file_types_raises_when_unreachable_without_fallback(
+    client: CompassClient, respx_mock: MockRouter
+):
+    """Declining the fallback keeps deployment reachability visible to the caller."""
+    respx_mock.get("http://test.com/v1/config/supported-file-types").mock(side_effect=httpx.ConnectError("no route"))
+
+    with pytest.raises(CompassNetworkError):
+        client.get_supported_file_types(fallback_on_failure=False, max_retries=1)
+
+
+@respx.mock
+def test_is_file_type_supported_answers_baseline_types_without_querying(client: CompassClient, respx_mock: MockRouter):
+    """File types every deployment accepts need no request, which is the point of the baseline."""
+    route = respx_mock.get("http://test.com/v1/config/supported-file-types")
+
+    assert client.is_file_type_supported(filename="report.pdf") is True
+    assert not route.called
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    200,
+    response_body={"file_types": [{"mime_types": ["audio/mpeg", "audio/mp3"], "extensions": [".mp3"]}]},
+)
+def test_is_file_type_supported_queries_deployment_for_types_outside_the_baseline(client: CompassClient):
+    """Capability-gated types are absent from the baseline, so only the deployment can answer."""
+    assert client.is_file_type_supported(filename="podcast.mp3") is True
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    200,
+    response_body={"file_types": [{"mime_types": ["audio/mpeg"], "extensions": [".mp3"]}]},
+)
+def test_is_file_type_supported_reuses_the_deployment_answer_across_calls(client: CompassClient):
+    """mock_endpoint asserts exactly one call, so three checks proving the answer is cached."""
+    assert client.is_file_type_supported(filename="first.mp3") is True
+    assert client.is_file_type_supported(filename="second.mp3") is True
+    assert client.is_file_type_supported(filename="clip.avi") is False
+
+
+@respx.mock
+def test_is_file_type_supported_returns_false_when_deployment_cannot_answer(
+    client: CompassClient, respx_mock: MockRouter
+):
+    """False is the safe answer: better to skip a file than upload one the deployment rejects."""
+    respx_mock.get("http://test.com/v1/config/supported-file-types").mock(side_effect=httpx.ConnectError("no route"))
+
+    assert client.is_file_type_supported(filename="podcast.mp3", max_retries=1) is False
+
+
+@respx.mock
+def test_is_file_type_supported_does_not_cache_a_failed_lookup(client: CompassClient, respx_mock: MockRouter):
+    """One transient failure must not narrow this client's answers for the rest of its life."""
+    route = respx_mock.get("http://test.com/v1/config/supported-file-types")
+    route.mock(side_effect=httpx.ConnectError("no route"))
+
+    assert client.is_file_type_supported(filename="podcast.mp3", max_retries=1) is False
+
+    route.mock(
+        return_value=httpx.Response(200, json={"file_types": [{"mime_types": ["audio/mpeg"], "extensions": [".mp3"]}]})
+    )
+
+    assert client.is_file_type_supported(filename="podcast.mp3") is True
+
+
+@respx.mock
+def test_is_file_type_supported_without_arguments_raises_value_error(client: CompassClient, respx_mock: MockRouter):
+    """Calling with no identifiers is a programming error rather than a silent False."""
+    respx_mock.get("http://test.com/v1/config/supported-file-types")
+
+    with pytest.raises(ValueError, match="At least one of filename or mime_type"):
+        client.is_file_type_supported()
 
 
 @respx.mock

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -87,6 +87,20 @@ def test_supports_uppercase_mime_type_returns_true(supported_file_types: Support
     assert supported_file_types.supports(mime_type="Application/PDF") is True
 
 
+def test_supports_advertised_mime_type_with_internal_capitals_returns_true() -> None:
+    """Compass advertises types such as macroEnabled.12, which must match as advertised."""
+    response = SupportedFileTypesResponse(
+        file_types=[
+            SupportedFileType(
+                mime_types=["application/vnd.ms-excel.sheet.macroEnabled.12"],
+                extensions=[".xlsm"],
+            )
+        ]
+    )
+    assert response.supports(mime_type="application/vnd.ms-excel.sheet.macroEnabled.12") is True
+    assert response.supports(mime_type="application/vnd.ms-excel.sheet.macroenabled.12") is True
+
+
 def test_supports_mime_only_format_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
     """Formats advertised without extensions are still matchable by MIME type."""
     assert supported_file_types.supports(mime_type="application/octet-stream") is True

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,0 +1,166 @@
+# pyright: reportPrivateUsage=false
+
+from cohere_compass.content_types import (
+    BASELINE_SUPPORTED_FILE_TYPES,
+    CONTENT_TYPE_ALIASES,
+    CONTENT_TYPE_REQUIRED_CAPABILITIES,
+    CONTENT_TYPE_TO_EXTENSIONS,
+    EXTENSION_TO_CONTENT_TYPE,
+    ParserCapability,
+    _supported_content_types,
+    resolve_supported_file_types,
+)
+from cohere_compass.models.config import SupportedFileTypesResponse
+from cohere_compass.models.documents import ContentTypeEnum
+
+ALL_CAPABILITIES = frozenset(ParserCapability)
+
+
+def test_supported_content_types_without_capabilities_excludes_every_gated_type() -> None:
+    """The baseline must omit anything a deployment could be missing the backend for."""
+    baseline = set(_supported_content_types(frozenset()))
+    assert baseline.isdisjoint(CONTENT_TYPE_REQUIRED_CAPABILITIES)
+
+
+def test_supported_content_types_without_capabilities_includes_every_ungated_type() -> None:
+    """The gating map is the only thing that removes a type, so the rest must be present."""
+    baseline = set(_supported_content_types(frozenset()))
+    assert baseline == set(ContentTypeEnum) - set(CONTENT_TYPE_REQUIRED_CAPABILITIES)
+
+
+def test_supported_content_types_with_asr_includes_audio_but_not_video() -> None:
+    """Video needs the video LLM on top of ASR, so ASR alone is not enough."""
+    with_asr = set(_supported_content_types([ParserCapability.ASR]))
+    assert ContentTypeEnum.AudioMpeg in with_asr
+    assert ContentTypeEnum.AudioWav in with_asr
+    assert ContentTypeEnum.VideoMp4 not in with_asr
+    assert ContentTypeEnum.VideoXMsVideo not in with_asr
+
+
+def test_supported_content_types_with_every_capability_includes_every_type() -> None:
+    """A fully provisioned deployment accepts the whole taxonomy."""
+    assert set(_supported_content_types(ALL_CAPABILITIES)) == set(ContentTypeEnum)
+
+
+def test_resolve_supported_file_types_folds_aliases_into_canonical_type() -> None:
+    """Aliases share their canonical type's entry and extensions rather than forming their own."""
+    resolved = resolve_supported_file_types(_supported_content_types(ALL_CAPABILITIES))
+
+    markdown = next(f for f in resolved if "text/markdown" in f.mime_types)
+    assert markdown.mime_types[0] == "text/markdown"
+    assert {"text/x-markdown", "application/markdown", "application/x-markdown"} <= set(markdown.mime_types)
+    assert markdown.extensions == [".md"]
+
+    yaml = next(f for f in resolved if "application/yaml" in f.mime_types)
+    assert yaml.mime_types[0] == "application/yaml"
+    assert {"application/x-yaml", "text/yaml", "text/x-yaml"} <= set(yaml.mime_types)
+    assert yaml.extensions == [".yaml", ".yml"]
+
+    jpeg = next(f for f in resolved if "image/jpeg" in f.mime_types)
+    assert jpeg.mime_types[0] == "image/jpeg"
+    assert "image/jpg" in jpeg.mime_types
+    assert jpeg.extensions == [".jpeg", ".jpg"]
+
+
+def test_resolve_supported_file_types_never_emits_an_alias_as_a_canonical_type() -> None:
+    """Each entry leads with the canonical type, which is what upload validation keys on."""
+    resolved = resolve_supported_file_types(_supported_content_types(ALL_CAPABILITIES))
+    canonical_mime_types = {f.mime_types[0] for f in resolved}
+    assert not (canonical_mime_types & {alias.value for alias in CONTENT_TYPE_ALIASES})
+
+
+def test_resolve_supported_file_types_covers_every_non_alias_type_exactly_once() -> None:
+    """No accepted type is dropped from, or duplicated across, the resolved entries."""
+    resolved = resolve_supported_file_types(_supported_content_types(ALL_CAPABILITIES))
+    canonical_mime_types = [f.mime_types[0] for f in resolved]
+
+    assert len(canonical_mime_types) == len(set(canonical_mime_types))
+    assert set(canonical_mime_types) == {ct.value for ct in ContentTypeEnum} - {
+        alias.value for alias in CONTENT_TYPE_ALIASES
+    }
+
+
+def test_resolve_supported_file_types_omits_aliases_whose_canonical_type_is_unsupported() -> None:
+    """An alias must not leak in on its own; audio/mp3 tracks audio/mpeg's ASR gate."""
+    baseline = resolve_supported_file_types(_supported_content_types(frozenset()))
+    assert "audio/mp3" not in {m for f in baseline for m in f.mime_types}
+
+
+def test_resolve_supported_file_types_omits_unsupported_aliases_of_a_supported_canonical_type() -> None:
+    """An entry lists only the aliases the caller actually accepts."""
+    resolved = resolve_supported_file_types([ContentTypeEnum.ImageJpeg])
+    assert [f.mime_types for f in resolved] == [["image/jpeg"]]
+
+
+def test_resolve_supported_file_types_gives_extensionless_types_an_empty_extension_list() -> None:
+    """MIME-only formats advertise no suffix rather than an empty-string suffix."""
+    resolved = resolve_supported_file_types(_supported_content_types(ALL_CAPABILITIES))
+    octet_stream = next(f for f in resolved if "application/octet-stream" in f.mime_types)
+    assert octet_stream.extensions == []
+
+
+def test_content_type_to_extensions_round_trips_every_authored_extension() -> None:
+    """The derived reverse mapping cannot drift from the authored extension table."""
+    for extension, content_type in EXTENSION_TO_CONTENT_TYPE.items():
+        assert extension in CONTENT_TYPE_TO_EXTENSIONS[content_type]
+
+
+def test_extension_table_never_maps_an_extension_to_an_alias() -> None:
+    """Extensions resolve to canonical types, the direction file detection runs."""
+    assert not (set(EXTENSION_TO_CONTENT_TYPE.values()) & set(CONTENT_TYPE_ALIASES))
+
+
+def test_only_known_content_types_lack_a_file_extension() -> None:
+    """A new content type must not silently end up with no extension; add one or list it here."""
+    extensionless = {ct for ct, extensions in CONTENT_TYPE_TO_EXTENSIONS.items() if not extensions}
+    assert extensionless - set(CONTENT_TYPE_ALIASES) == {
+        ContentTypeEnum.ApplicationOctetStream,
+        ContentTypeEnum.ApplicationVndCohereCompassV1Json,
+    }
+
+
+def test_baseline_supported_file_types_matches_the_capability_free_derivation() -> None:
+    """The published constant is the derivation, not a hand-maintained literal."""
+    assert BASELINE_SUPPORTED_FILE_TYPES == SupportedFileTypesResponse(
+        file_types=resolve_supported_file_types(_supported_content_types(frozenset()))
+    )
+
+
+def test_baseline_supported_file_types_advertises_no_audio_or_video() -> None:
+    """The SDK cannot detect ASR or the video LLM, so the baseline must never promise media."""
+    assert not any(m.startswith(("audio/", "video/")) for m in BASELINE_SUPPORTED_FILE_TYPES.mime_types)
+    assert not {".mp3", ".wav", ".mp4", ".avi"} & BASELINE_SUPPORTED_FILE_TYPES.extensions
+
+
+def test_baseline_supported_file_types_supports_ungated_formats() -> None:
+    """Formats needing no gated backend are safe to advertise on any deployment."""
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(filename="report.pdf") is True
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(filename="values.yml") is True
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(filename="budget.xlsm") is True
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(mime_type="application/x-yaml") is True
+
+
+def test_baseline_supported_file_types_rejects_gated_and_unknown_formats() -> None:
+    """Gated media and formats Compass never accepts both answer False."""
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(filename="interview.mp3") is False
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(mime_type="audio/mpeg") is False
+    assert BASELINE_SUPPORTED_FILE_TYPES.supports(filename="archive.zip") is False
+
+
+def test_baseline_supported_file_types_extensions_are_lowercase_and_dot_prefixed() -> None:
+    """SupportedFileType documents this shape, and supports() relies on it when matching."""
+    for extension in BASELINE_SUPPORTED_FILE_TYPES.extensions:
+        assert extension == extension.lower()
+        assert extension.startswith(".")
+
+
+def test_baseline_supported_file_types_accepts_every_mime_type_it_advertises() -> None:
+    """Anything the baseline lists must pass supports(); mixed-case types such as macroEnabled.12 included."""
+    for mime_type in BASELINE_SUPPORTED_FILE_TYPES.mime_types:
+        assert BASELINE_SUPPORTED_FILE_TYPES.supports(mime_type=mime_type) is True
+
+
+def test_baseline_supported_file_types_accepts_every_extension_it_advertises() -> None:
+    """Anything the baseline lists must pass supports(), so callers and the tables cannot disagree."""
+    for extension in BASELINE_SUPPORTED_FILE_TYPES.extensions:
+        assert BASELINE_SUPPORTED_FILE_TYPES.supports(filename=f"document{extension}") is True


### PR DESCRIPTION
To support integration of the supported file types workflow with North.

This in-houses fully the management of what sort of files Compass supports while giving a baseline to the consuming application that they can easily import and use.