### PR TITLE
feat: fall back to a minimal supported file types set

### DIFF
--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -14,7 +14,7 @@ import re
 import threading
 import uuid
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from datetime import timedelta
 from statistics import mean
@@ -42,7 +42,7 @@ from cohere_compass.constants import (
     DEFAULT_RETRY_WAIT,
     URL_SAFE_STRING_PATTERN,
 )
-from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
+from cohere_compass.content_types import ParserCapability, supported_file_types
 from cohere_compass.exceptions import (
     CompassClientError,
     CompassError,
@@ -403,13 +403,13 @@ class CompassClient:
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
         fallback_on_failure: bool = True,
+        capabilities: Collection[ParserCapability] = (),
     ) -> SupportedFileTypesResponse:
         """
         Get the file types this Compass deployment can currently parse and index.
 
         If the deployment is unreachable or does not implement this endpoint, returns
-        :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` when
-        ``fallback_on_failure`` is True.
+        the locally known set for ``capabilities`` when ``fallback_on_failure`` is True.
 
         :param max_retries: Maximum number of retries for failed requests. If not
             provided, the default from the client will be used.
@@ -417,8 +417,10 @@ class CompassClient:
             from the client will be used.
         :param timeout: Request timeout duration. If not provided, the default from the
             client will be used.
-        :param fallback_on_failure: Return the minimal set on network failure or HTTP
-            404 instead of raising. Defaults to True.
+        :param fallback_on_failure: Return the local set on network failure or HTTP 404
+            instead of raising. Defaults to True.
+        :param capabilities: Parser backends this deployment is known to have. Used
+            only when falling back. Defaults to none, so audio and video are omitted.
 
         :return: The supported file types, pairing accepted MIME types with the file
             extensions that map to them.
@@ -432,7 +434,7 @@ class CompassClient:
             )
         except (CompassNetworkError, CompassClientError) as exc:
             if fallback_on_failure and (isinstance(exc, CompassNetworkError) or exc.code == 404):
-                return MINIMAL_SUPPORTED_FILE_TYPES
+                return supported_file_types(capabilities)
             raise
         if not isinstance(result.result, dict):
             raise ValueError("Invalid response from Compass API")
@@ -448,13 +450,13 @@ class CompassClient:
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
         fallback_on_failure: bool = True,
+        capabilities: Collection[ParserCapability] = (),
     ) -> bool:
         """
         Return whether this Compass deployment accepts a file.
 
-        Types in :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` are
-        resolved locally. All others query the deployment and cache the result on this
-        client.
+        Types that need only ``capabilities`` are resolved locally. All others query
+        the deployment and cache the result on this client.
 
         :param filename: File name to check. Only its extension is used.
         :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
@@ -466,13 +468,14 @@ class CompassClient:
         :param timeout: Request timeout duration. If not provided, the default from the
             client will be used.
         :param fallback_on_failure: Passed to :meth:`get_supported_file_types` when the
-            file is not in the minimal set.
+            file is not in the local set.
+        :param capabilities: Parser backends this deployment is known to have.
 
         :return: True if Compass accepts the file, False otherwise.
 
         :raises ValueError: If neither filename nor mime_type is provided.
         """
-        if MINIMAL_SUPPORTED_FILE_TYPES.supports(filename=filename, mime_type=mime_type):
+        if supported_file_types(capabilities).supports(filename=filename, mime_type=mime_type):
             return True
         if self._supported_file_types is None:
             self._supported_file_types = self.get_supported_file_types(
@@ -480,6 +483,7 @@ class CompassClient:
                 retry_wait=retry_wait,
                 timeout=timeout,
                 fallback_on_failure=fallback_on_failure,
+                capabilities=capabilities,
             )
         return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -346,7 +346,6 @@ class CompassClient:
             raise ValueError("retry_wait must be a non-negative integer.")
         self.max_retries = max_retries
         self.retry_wait = retry_wait
-        self._supported_file_types: SupportedFileTypesResponse | None = None
 
     def close(self):
         """Close the httpx client if it was created by this instance."""
@@ -440,52 +439,6 @@ class CompassClient:
             raise ValueError("Invalid response from Compass API")
 
         return SupportedFileTypesResponse.model_validate(result.result)
-
-    def is_file_type_supported(
-        self,
-        *,
-        filename: str | None = None,
-        mime_type: str | None = None,
-        max_retries: int | None = None,
-        retry_wait: timedelta | None = None,
-        timeout: timedelta | None = None,
-        fallback_on_failure: bool = True,
-        capabilities: Collection[ParserCapability] = (),
-    ) -> bool:
-        """
-        Return whether this Compass deployment accepts a file.
-
-        Types that need only ``capabilities`` are resolved locally. All others query
-        the deployment and cache the result on this client.
-
-        :param filename: File name to check. Only its extension is used.
-        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
-            parameters such as "; charset=utf-8".
-        :param max_retries: Maximum number of retries for failed requests. If not
-            provided, the default from the client will be used.
-        :param retry_wait: Time to wait between retries. If not provided, the default
-            from the client will be used.
-        :param timeout: Request timeout duration. If not provided, the default from the
-            client will be used.
-        :param fallback_on_failure: Passed to :meth:`get_supported_file_types` when the
-            file is not in the local set.
-        :param capabilities: Parser backends this deployment is known to have.
-
-        :return: True if Compass accepts the file, False otherwise.
-
-        :raises ValueError: If neither filename nor mime_type is provided.
-        """
-        if supported_file_types(capabilities).supports(filename=filename, mime_type=mime_type):
-            return True
-        if self._supported_file_types is None:
-            self._supported_file_types = self.get_supported_file_types(
-                max_retries=max_retries,
-                retry_wait=retry_wait,
-                timeout=timeout,
-                fallback_on_failure=fallback_on_failure,
-                capabilities=capabilities,
-            )
-        return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 
     def create_index(
         self,

--- a/cohere_compass/clients/compass.py
+++ b/cohere_compass/clients/compass.py
@@ -42,10 +42,13 @@ from cohere_compass.constants import (
     DEFAULT_RETRY_WAIT,
     URL_SAFE_STRING_PATTERN,
 )
+from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
 from cohere_compass.exceptions import (
+    CompassClientError,
     CompassError,
     CompassInsertionError,
     CompassMaxErrorRateExceeded,
+    CompassNetworkError,
     handle_httpx_exceptions,
 )
 from cohere_compass.models import (
@@ -343,6 +346,7 @@ class CompassClient:
             raise ValueError("retry_wait must be a non-negative integer.")
         self.max_retries = max_retries
         self.retry_wait = retry_wait
+        self._supported_file_types: SupportedFileTypesResponse | None = None
 
     def close(self):
         """Close the httpx client if it was created by this instance."""
@@ -398,12 +402,14 @@ class CompassClient:
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
+        fallback_on_failure: bool = True,
     ) -> SupportedFileTypesResponse:
         """
-        Get the file types Compass can currently parse and index.
+        Get the file types this Compass deployment can currently parse and index.
 
-        The result depends on the deployment's runtime configuration, so it describes
-        what this Compass deployment accepts rather than a fixed capability list.
+        If the deployment is unreachable or does not implement this endpoint, returns
+        :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` when
+        ``fallback_on_failure`` is True.
 
         :param max_retries: Maximum number of retries for failed requests. If not
             provided, the default from the client will be used.
@@ -411,23 +417,71 @@ class CompassClient:
             from the client will be used.
         :param timeout: Request timeout duration. If not provided, the default from the
             client will be used.
+        :param fallback_on_failure: Return the minimal set on network failure or HTTP
+            404 instead of raising. Defaults to True.
 
         :return: The supported file types, pairing accepted MIME types with the file
             extensions that map to them.
-
-        :raises CompassClientError: With code 404 against Compass deployments that
-            predate this endpoint.
         """
-        result = self._send_request(
-            api_name="get_supported_file_types",
-            max_retries=max_retries,
-            retry_wait=retry_wait,
-            timeout=timeout,
-        )
+        try:
+            result = self._send_request(
+                api_name="get_supported_file_types",
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+            )
+        except (CompassNetworkError, CompassClientError) as exc:
+            if fallback_on_failure and (isinstance(exc, CompassNetworkError) or exc.code == 404):
+                return MINIMAL_SUPPORTED_FILE_TYPES
+            raise
         if not isinstance(result.result, dict):
             raise ValueError("Invalid response from Compass API")
 
         return SupportedFileTypesResponse.model_validate(result.result)
+
+    def is_file_type_supported(
+        self,
+        *,
+        filename: str | None = None,
+        mime_type: str | None = None,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+        fallback_on_failure: bool = True,
+    ) -> bool:
+        """
+        Return whether this Compass deployment accepts a file.
+
+        Types in :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` are
+        resolved locally. All others query the deployment and cache the result on this
+        client.
+
+        :param filename: File name to check. Only its extension is used.
+        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
+            parameters such as "; charset=utf-8".
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+        :param fallback_on_failure: Passed to :meth:`get_supported_file_types` when the
+            file is not in the minimal set.
+
+        :return: True if Compass accepts the file, False otherwise.
+
+        :raises ValueError: If neither filename nor mime_type is provided.
+        """
+        if MINIMAL_SUPPORTED_FILE_TYPES.supports(filename=filename, mime_type=mime_type):
+            return True
+        if self._supported_file_types is None:
+            self._supported_file_types = self.get_supported_file_types(
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+                fallback_on_failure=fallback_on_failure,
+            )
+        return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 
     def create_index(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -43,10 +43,13 @@ from cohere_compass.constants import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_RETRY_WAIT,
 )
+from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
 from cohere_compass.exceptions import (
+    CompassClientError,
     CompassError,
     CompassInsertionError,
     CompassMaxErrorRateExceeded,
+    CompassNetworkError,
     handle_httpx_exceptions,
 )
 from cohere_compass.models import (
@@ -157,6 +160,7 @@ class CompassAsyncClient:
             raise ValueError("default_sleep_retry_seconds must be a non-negative integer.")
         self.max_retries = max_retries
         self.retry_wait = retry_wait
+        self._supported_file_types: SupportedFileTypesResponse | None = None
 
     async def aclose(self):
         """Close the httpx client if it was created by the CompassAsyncClient."""
@@ -215,12 +219,14 @@ class CompassAsyncClient:
         max_retries: int | None = None,
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
+        fallback_on_failure: bool = True,
     ) -> SupportedFileTypesResponse:
         """
-        Get the file types Compass can currently parse and index.
+        Get the file types this Compass deployment can currently parse and index.
 
-        The result depends on the deployment's runtime configuration, so it describes
-        what this Compass deployment accepts rather than a fixed capability list.
+        If the deployment is unreachable or does not implement this endpoint, returns
+        :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` when
+        ``fallback_on_failure`` is True.
 
         :param max_retries: Maximum number of retries for failed requests. If not
             provided, the default from the client will be used.
@@ -228,23 +234,71 @@ class CompassAsyncClient:
             from the client will be used.
         :param timeout: Request timeout duration. If not provided, the default from the
             client will be used.
+        :param fallback_on_failure: Return the minimal set on network failure or HTTP
+            404 instead of raising. Defaults to True.
 
         :return: The supported file types, pairing accepted MIME types with the file
             extensions that map to them.
-
-        :raises CompassClientError: With code 404 against Compass deployments that
-            predate this endpoint.
         """
-        result = await self._send_request(
-            api_name="get_supported_file_types",
-            max_retries=max_retries,
-            retry_wait=retry_wait,
-            timeout=timeout,
-        )
+        try:
+            result = await self._send_request(
+                api_name="get_supported_file_types",
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+            )
+        except (CompassNetworkError, CompassClientError) as exc:
+            if fallback_on_failure and (isinstance(exc, CompassNetworkError) or exc.code == 404):
+                return MINIMAL_SUPPORTED_FILE_TYPES
+            raise
         if not isinstance(result.result, dict):
             raise ValueError("Invalid response from Compass API")
 
         return SupportedFileTypesResponse.model_validate(result.result)
+
+    async def is_file_type_supported(
+        self,
+        *,
+        filename: str | None = None,
+        mime_type: str | None = None,
+        max_retries: int | None = None,
+        retry_wait: timedelta | None = None,
+        timeout: timedelta | None = None,
+        fallback_on_failure: bool = True,
+    ) -> bool:
+        """
+        Return whether this Compass deployment accepts a file.
+
+        Types in :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` are
+        resolved locally. All others query the deployment and cache the result on this
+        client.
+
+        :param filename: File name to check. Only its extension is used.
+        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
+            parameters such as "; charset=utf-8".
+        :param max_retries: Maximum number of retries for failed requests. If not
+            provided, the default from the client will be used.
+        :param retry_wait: Time to wait between retries. If not provided, the default
+            from the client will be used.
+        :param timeout: Request timeout duration. If not provided, the default from the
+            client will be used.
+        :param fallback_on_failure: Passed to :meth:`get_supported_file_types` when the
+            file is not in the minimal set.
+
+        :return: True if Compass accepts the file, False otherwise.
+
+        :raises ValueError: If neither filename nor mime_type is provided.
+        """
+        if MINIMAL_SUPPORTED_FILE_TYPES.supports(filename=filename, mime_type=mime_type):
+            return True
+        if self._supported_file_types is None:
+            self._supported_file_types = await self.get_supported_file_types(
+                max_retries=max_retries,
+                retry_wait=retry_wait,
+                timeout=timeout,
+                fallback_on_failure=fallback_on_failure,
+            )
+        return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 
     async def create_index(
         self,

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -12,7 +12,7 @@ import os
 import re
 import uuid
 from collections import deque
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable, Collection, Iterable
 from datetime import timedelta
 from statistics import mean
 from types import TracebackType
@@ -43,7 +43,7 @@ from cohere_compass.constants import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_RETRY_WAIT,
 )
-from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
+from cohere_compass.content_types import ParserCapability, supported_file_types
 from cohere_compass.exceptions import (
     CompassClientError,
     CompassError,
@@ -220,13 +220,13 @@ class CompassAsyncClient:
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
         fallback_on_failure: bool = True,
+        capabilities: Collection[ParserCapability] = (),
     ) -> SupportedFileTypesResponse:
         """
         Get the file types this Compass deployment can currently parse and index.
 
         If the deployment is unreachable or does not implement this endpoint, returns
-        :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` when
-        ``fallback_on_failure`` is True.
+        the locally known set for ``capabilities`` when ``fallback_on_failure`` is True.
 
         :param max_retries: Maximum number of retries for failed requests. If not
             provided, the default from the client will be used.
@@ -234,8 +234,10 @@ class CompassAsyncClient:
             from the client will be used.
         :param timeout: Request timeout duration. If not provided, the default from the
             client will be used.
-        :param fallback_on_failure: Return the minimal set on network failure or HTTP
-            404 instead of raising. Defaults to True.
+        :param fallback_on_failure: Return the local set on network failure or HTTP 404
+            instead of raising. Defaults to True.
+        :param capabilities: Parser backends this deployment is known to have. Used
+            only when falling back. Defaults to none, so audio and video are omitted.
 
         :return: The supported file types, pairing accepted MIME types with the file
             extensions that map to them.
@@ -249,7 +251,7 @@ class CompassAsyncClient:
             )
         except (CompassNetworkError, CompassClientError) as exc:
             if fallback_on_failure and (isinstance(exc, CompassNetworkError) or exc.code == 404):
-                return MINIMAL_SUPPORTED_FILE_TYPES
+                return supported_file_types(capabilities)
             raise
         if not isinstance(result.result, dict):
             raise ValueError("Invalid response from Compass API")
@@ -265,13 +267,13 @@ class CompassAsyncClient:
         retry_wait: timedelta | None = None,
         timeout: timedelta | None = None,
         fallback_on_failure: bool = True,
+        capabilities: Collection[ParserCapability] = (),
     ) -> bool:
         """
         Return whether this Compass deployment accepts a file.
 
-        Types in :data:`~cohere_compass.content_types.MINIMAL_SUPPORTED_FILE_TYPES` are
-        resolved locally. All others query the deployment and cache the result on this
-        client.
+        Types that need only ``capabilities`` are resolved locally. All others query
+        the deployment and cache the result on this client.
 
         :param filename: File name to check. Only its extension is used.
         :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
@@ -283,13 +285,14 @@ class CompassAsyncClient:
         :param timeout: Request timeout duration. If not provided, the default from the
             client will be used.
         :param fallback_on_failure: Passed to :meth:`get_supported_file_types` when the
-            file is not in the minimal set.
+            file is not in the local set.
+        :param capabilities: Parser backends this deployment is known to have.
 
         :return: True if Compass accepts the file, False otherwise.
 
         :raises ValueError: If neither filename nor mime_type is provided.
         """
-        if MINIMAL_SUPPORTED_FILE_TYPES.supports(filename=filename, mime_type=mime_type):
+        if supported_file_types(capabilities).supports(filename=filename, mime_type=mime_type):
             return True
         if self._supported_file_types is None:
             self._supported_file_types = await self.get_supported_file_types(
@@ -297,6 +300,7 @@ class CompassAsyncClient:
                 retry_wait=retry_wait,
                 timeout=timeout,
                 fallback_on_failure=fallback_on_failure,
+                capabilities=capabilities,
             )
         return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 

--- a/cohere_compass/clients/compass_async.py
+++ b/cohere_compass/clients/compass_async.py
@@ -160,7 +160,6 @@ class CompassAsyncClient:
             raise ValueError("default_sleep_retry_seconds must be a non-negative integer.")
         self.max_retries = max_retries
         self.retry_wait = retry_wait
-        self._supported_file_types: SupportedFileTypesResponse | None = None
 
     async def aclose(self):
         """Close the httpx client if it was created by the CompassAsyncClient."""
@@ -257,52 +256,6 @@ class CompassAsyncClient:
             raise ValueError("Invalid response from Compass API")
 
         return SupportedFileTypesResponse.model_validate(result.result)
-
-    async def is_file_type_supported(
-        self,
-        *,
-        filename: str | None = None,
-        mime_type: str | None = None,
-        max_retries: int | None = None,
-        retry_wait: timedelta | None = None,
-        timeout: timedelta | None = None,
-        fallback_on_failure: bool = True,
-        capabilities: Collection[ParserCapability] = (),
-    ) -> bool:
-        """
-        Return whether this Compass deployment accepts a file.
-
-        Types that need only ``capabilities`` are resolved locally. All others query
-        the deployment and cache the result on this client.
-
-        :param filename: File name to check. Only its extension is used.
-        :param mime_type: MIME type to check. Matched case-insensitively, ignoring any
-            parameters such as "; charset=utf-8".
-        :param max_retries: Maximum number of retries for failed requests. If not
-            provided, the default from the client will be used.
-        :param retry_wait: Time to wait between retries. If not provided, the default
-            from the client will be used.
-        :param timeout: Request timeout duration. If not provided, the default from the
-            client will be used.
-        :param fallback_on_failure: Passed to :meth:`get_supported_file_types` when the
-            file is not in the local set.
-        :param capabilities: Parser backends this deployment is known to have.
-
-        :return: True if Compass accepts the file, False otherwise.
-
-        :raises ValueError: If neither filename nor mime_type is provided.
-        """
-        if supported_file_types(capabilities).supports(filename=filename, mime_type=mime_type):
-            return True
-        if self._supported_file_types is None:
-            self._supported_file_types = await self.get_supported_file_types(
-                max_retries=max_retries,
-                retry_wait=retry_wait,
-                timeout=timeout,
-                fallback_on_failure=fallback_on_failure,
-                capabilities=capabilities,
-            )
-        return self._supported_file_types.supports(filename=filename, mime_type=mime_type)
 
     async def create_index(
         self,

--- a/cohere_compass/content_types.py
+++ b/cohere_compass/content_types.py
@@ -1,0 +1,88 @@
+"""The minimal set of file types every Compass deployment accepts."""
+
+from typing import NamedTuple
+
+from cohere_compass.models.config import SupportedFileType, SupportedFileTypesResponse
+
+
+class _FileType(NamedTuple):
+    mime_types: tuple[str, ...]
+    extensions: tuple[str, ...]
+    required_capabilities: tuple[str, ...] = ()
+
+
+# Each record is the MIME types and extensions for one format, plus any Compass
+# capabilities that format requires. Records with no required capabilities are the
+# minimal set every deployment accepts.
+_FILE_TYPES: tuple[_FileType, ...] = (
+    _FileType(("text/plain",), (".txt",)),
+    _FileType(("text/html",), (".htm", ".html")),
+    _FileType(("text/csv",), (".csv",)),
+    _FileType(("text/tab-separated-values",), (".tab", ".tsv")),
+    _FileType(
+        ("text/markdown", "application/markdown", "application/x-markdown", "text/x-markdown"),
+        (".md",),
+    ),
+    _FileType(("text/org",), (".org",)),
+    _FileType(("text/prs.fallenstein.rst",), (".rst",)),
+    _FileType(("application/json",), (".json",)),
+    _FileType(("application/jsonl", "application/json-lines"), (".jsonl",)),
+    _FileType(("application/pdf",), (".pdf",)),
+    _FileType(("application/xml",), (".xml",)),
+    _FileType(("application/msword",), (".doc",)),
+    _FileType(
+        ("application/vnd.openxmlformats-officedocument.wordprocessingml.document",),
+        (".docx",),
+    ),
+    _FileType(("application/vnd.ms-excel",), (".xls",)),
+    _FileType(
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/xlsx"),
+        (".xlsx",),
+    ),
+    _FileType(("application/vnd.ms-excel.sheet.macroEnabled.12",), (".xlsm",)),
+    _FileType(
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.template",),
+        (".xltx",),
+    ),
+    _FileType(("application/vnd.ms-excel.template.macroEnabled.12",), (".xltm",)),
+    _FileType(("application/vnd.ms-powerpoint",), (".ppt",)),
+    _FileType(
+        ("application/vnd.openxmlformats-officedocument.presentationml.presentation",),
+        (".pptx",),
+    ),
+    _FileType(("application/epub+zip",), (".epub",)),
+    _FileType(("application/vnd.oasis.opendocument.text",), (".odt",)),
+    _FileType(("application/vnd.oasis.opendocument.spreadsheet",), (".ods",)),
+    _FileType(("application/vnd.oasis.opendocument.presentation",), (".odp",)),
+    _FileType(("application/vnd.ms-outlook",), (".msg",)),
+    _FileType(("application/octet-stream",), ()),
+    _FileType(("application/rtf",), (".rtf",)),
+    _FileType(
+        ("application/yaml", "application/x-yaml", "text/x-yaml", "text/yaml"),
+        (".yaml", ".yml"),
+    ),
+    _FileType(("application/vnd.cohere.compassV1+json",), ()),
+    _FileType(("application/x-hwp",), (".hwp",)),
+    _FileType(("application/x-hwpx",), (".hwpx",)),
+    _FileType(("image/jpeg", "image/jpg"), (".jpeg", ".jpg")),
+    _FileType(("image/png",), (".png",)),
+    _FileType(("image/heic",), (".heic",)),
+    _FileType(("image/tiff",), (".tiff",)),
+    _FileType(("image/bmp",), (".bmp",)),
+    _FileType(("image/gif",), (".gif",)),
+    _FileType(("image/svg+xml",), (".svg",)),
+    _FileType(("image/webp",), (".webp",)),
+    _FileType(("message/rfc822",), (".eml",)),
+    _FileType(("audio/mpeg", "audio/mp3"), (".mp3",), ("asr",)),
+    _FileType(("audio/wav",), (".wav",), ("asr",)),
+    _FileType(("video/mp4",), (".mp4",), ("asr", "video_llm")),
+    _FileType(("video/x-msvideo",), (".avi",), ("asr", "video_llm")),
+)
+
+MINIMAL_SUPPORTED_FILE_TYPES = SupportedFileTypesResponse(
+    file_types=[
+        SupportedFileType(mime_types=list(file_type.mime_types), extensions=list(file_type.extensions))
+        for file_type in _FILE_TYPES
+        if not file_type.required_capabilities
+    ]
+)

--- a/cohere_compass/content_types.py
+++ b/cohere_compass/content_types.py
@@ -1,19 +1,26 @@
-"""The minimal set of file types every Compass deployment accepts."""
+"""File types Compass can parse, gated by optional parser capabilities."""
 
+from collections.abc import Collection
+from enum import Enum
 from typing import NamedTuple
 
 from cohere_compass.models.config import SupportedFileType, SupportedFileTypesResponse
 
 
+class ParserCapability(str, Enum):
+    """A gated parser backend a Compass deployment may have."""
+
+    ASR = "asr"
+    VIDEO_LLM = "video_llm"
+
+
 class _FileType(NamedTuple):
     mime_types: tuple[str, ...]
     extensions: tuple[str, ...]
-    required_capabilities: tuple[str, ...] = ()
+    required_capabilities: tuple[ParserCapability, ...] = ()
 
 
-# Each record is the MIME types and extensions for one format, plus any Compass
-# capabilities that format requires. Records with no required capabilities are the
-# minimal set every deployment accepts.
+# MIME types, extensions, and any parser capabilities the format requires.
 _FILE_TYPES: tuple[_FileType, ...] = (
     _FileType(("text/plain",), (".txt",)),
     _FileType(("text/html",), (".htm", ".html")),
@@ -73,16 +80,22 @@ _FILE_TYPES: tuple[_FileType, ...] = (
     _FileType(("image/svg+xml",), (".svg",)),
     _FileType(("image/webp",), (".webp",)),
     _FileType(("message/rfc822",), (".eml",)),
-    _FileType(("audio/mpeg", "audio/mp3"), (".mp3",), ("asr",)),
-    _FileType(("audio/wav",), (".wav",), ("asr",)),
-    _FileType(("video/mp4",), (".mp4",), ("asr", "video_llm")),
-    _FileType(("video/x-msvideo",), (".avi",), ("asr", "video_llm")),
+    _FileType(("audio/mpeg", "audio/mp3"), (".mp3",), (ParserCapability.ASR,)),
+    _FileType(("audio/wav",), (".wav",), (ParserCapability.ASR,)),
+    _FileType(("video/mp4",), (".mp4",), (ParserCapability.ASR, ParserCapability.VIDEO_LLM)),
+    _FileType(("video/x-msvideo",), (".avi",), (ParserCapability.ASR, ParserCapability.VIDEO_LLM)),
 )
 
-MINIMAL_SUPPORTED_FILE_TYPES = SupportedFileTypesResponse(
-    file_types=[
-        SupportedFileType(mime_types=list(file_type.mime_types), extensions=list(file_type.extensions))
-        for file_type in _FILE_TYPES
-        if not file_type.required_capabilities
-    ]
-)
+
+def supported_file_types(
+    capabilities: Collection[ParserCapability] = (),
+) -> SupportedFileTypesResponse:
+    """File types accepted given the parser backends this deployment is known to have."""
+    available = frozenset(capabilities)
+    return SupportedFileTypesResponse(
+        file_types=[
+            SupportedFileType(mime_types=list(file_type.mime_types), extensions=list(file_type.extensions))
+            for file_type in _FILE_TYPES
+            if set(file_type.required_capabilities) <= available
+        ]
+    )

--- a/cohere_compass/models/config.py
+++ b/cohere_compass/models/config.py
@@ -291,7 +291,9 @@ class SupportedFileTypesResponse(BaseModel):
         if filename is None and mime_type is None:
             raise ValueError("At least one of filename or mime_type must be provided.")
 
-        if mime_type is not None and mime_type.split(";")[0].strip().lower() in self.mime_types:
-            return True
+        if mime_type is not None:
+            queried = mime_type.split(";")[0].strip().lower()
+            if any(queried == advertised.lower() for advertised in self.mime_types):
+                return True
 
         return filename is not None and PurePosixPath(filename).suffix.lower() in self.extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere-compass-sdk"
-version = "2.16.0"
+version = "2.17.0"
 authors = []
 description = "Cohere Compass SDK"
 readme = "README.md"

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -12,7 +12,7 @@ from respx import MockRouter
 
 from cohere_compass import GroupAuthorizationActions, GroupAuthorizationInput
 from cohere_compass.clients import CompassClient
-from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
+from cohere_compass.content_types import ParserCapability, supported_file_types
 from cohere_compass.exceptions import (
     CompassAuthError,
     CompassClientError,
@@ -613,7 +613,7 @@ def test_get_supported_file_types_handles_empty_file_types(client: CompassClient
 def test_get_supported_file_types_falls_back_on_older_deployment(client: CompassClient):
     result = client.get_supported_file_types()
 
-    assert result == MINIMAL_SUPPORTED_FILE_TYPES
+    assert result == supported_file_types()
 
 
 @mock_endpoint(
@@ -637,7 +637,21 @@ def test_get_supported_file_types_falls_back_on_timeout(client: CompassClient, r
 
     result = client.get_supported_file_types(max_retries=1, retry_wait=timedelta(0))
 
-    assert result == MINIMAL_SUPPORTED_FILE_TYPES
+    assert result == supported_file_types()
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    404,
+    response_body={"detail": "Not Found"},
+)
+def test_get_supported_file_types_fallback_includes_known_capabilities(client: CompassClient):
+    result = client.get_supported_file_types(capabilities=[ParserCapability.ASR])
+
+    assert result == supported_file_types([ParserCapability.ASR])
+    assert result.supports(filename="interview.mp3") is True
+    assert result.supports(filename="clip.mp4") is False
 
 
 @mock_endpoint(
@@ -658,6 +672,16 @@ def test_is_file_type_supported_resolves_minimal_types_locally(client: CompassCl
     )
 
     assert client.is_file_type_supported(filename="report.pdf") is True
+    assert not route.called
+
+
+@respx.mock
+def test_is_file_type_supported_resolves_known_capabilities_locally(client: CompassClient, respx_mock: MockRouter):
+    route = respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
+        return_value=httpx.Response(200, json={"file_types": []})
+    )
+
+    assert client.is_file_type_supported(filename="interview.mp3", capabilities=[ParserCapability.ASR]) is True
     assert not route.called
 
 

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from collections.abc import Callable
+from datetime import timedelta
 from typing import Any, Literal, cast
 
 import httpx
@@ -11,6 +12,7 @@ from respx import MockRouter
 
 from cohere_compass import GroupAuthorizationActions, GroupAuthorizationInput
 from cohere_compass.clients import CompassClient
+from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
 from cohere_compass.exceptions import (
     CompassAuthError,
     CompassClientError,
@@ -608,12 +610,79 @@ def test_get_supported_file_types_handles_empty_file_types(client: CompassClient
     404,
     response_body={"detail": "Not Found"},
 )
-def test_get_supported_file_types_raises_client_error_on_older_deployment(client: CompassClient):
-    """Deployments predating the endpoint return 404, which must surface as a catchable CompassClientError."""
+def test_get_supported_file_types_falls_back_on_older_deployment(client: CompassClient):
+    result = client.get_supported_file_types()
+
+    assert result == MINIMAL_SUPPORTED_FILE_TYPES
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    404,
+    response_body={"detail": "Not Found"},
+)
+def test_get_supported_file_types_raises_when_fallback_disabled(client: CompassClient):
     with pytest.raises(CompassClientError) as exc_info:
-        client.get_supported_file_types()
+        client.get_supported_file_types(fallback_on_failure=False)
 
     assert exc_info.value.code == 404
+
+
+@respx.mock
+def test_get_supported_file_types_falls_back_on_timeout(client: CompassClient, respx_mock: MockRouter):
+    respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
+        side_effect=httpx.TimeoutException("Request timeout")
+    )
+
+    result = client.get_supported_file_types(max_retries=1, retry_wait=timedelta(0))
+
+    assert result == MINIMAL_SUPPORTED_FILE_TYPES
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    401,
+    response_body={"detail": "Unauthorized"},
+)
+def test_get_supported_file_types_does_not_fallback_on_auth_error(client: CompassClient):
+    with pytest.raises(CompassAuthError):
+        client.get_supported_file_types()
+
+
+@respx.mock
+def test_is_file_type_supported_resolves_minimal_types_locally(client: CompassClient, respx_mock: MockRouter):
+    route = respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
+        return_value=httpx.Response(200, json={"file_types": []})
+    )
+
+    assert client.is_file_type_supported(filename="report.pdf") is True
+    assert not route.called
+
+
+@mock_endpoint(
+    "GET",
+    "http://test.com/v1/config/supported-file-types",
+    200,
+    response_body={"file_types": [{"mime_types": ["audio/mpeg"], "extensions": [".mp3"]}]},
+)
+def test_is_file_type_supported_queries_deployment_for_other_types(client: CompassClient):
+    assert client.is_file_type_supported(filename="interview.mp3") is True
+
+
+@respx.mock
+def test_is_file_type_supported_caches_deployment_response(client: CompassClient, respx_mock: MockRouter):
+    route = respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
+        return_value=httpx.Response(
+            200,
+            json={"file_types": [{"mime_types": ["audio/mpeg"], "extensions": [".mp3"]}]},
+        )
+    )
+
+    assert client.is_file_type_supported(filename="a.mp3") is True
+    assert client.is_file_type_supported(filename="b.mp3") is True
+    assert route.call_count == 1
 
 
 @respx.mock

--- a/tests/test_compass_client.py
+++ b/tests/test_compass_client.py
@@ -666,50 +666,6 @@ def test_get_supported_file_types_does_not_fallback_on_auth_error(client: Compas
 
 
 @respx.mock
-def test_is_file_type_supported_resolves_minimal_types_locally(client: CompassClient, respx_mock: MockRouter):
-    route = respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
-        return_value=httpx.Response(200, json={"file_types": []})
-    )
-
-    assert client.is_file_type_supported(filename="report.pdf") is True
-    assert not route.called
-
-
-@respx.mock
-def test_is_file_type_supported_resolves_known_capabilities_locally(client: CompassClient, respx_mock: MockRouter):
-    route = respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
-        return_value=httpx.Response(200, json={"file_types": []})
-    )
-
-    assert client.is_file_type_supported(filename="interview.mp3", capabilities=[ParserCapability.ASR]) is True
-    assert not route.called
-
-
-@mock_endpoint(
-    "GET",
-    "http://test.com/v1/config/supported-file-types",
-    200,
-    response_body={"file_types": [{"mime_types": ["audio/mpeg"], "extensions": [".mp3"]}]},
-)
-def test_is_file_type_supported_queries_deployment_for_other_types(client: CompassClient):
-    assert client.is_file_type_supported(filename="interview.mp3") is True
-
-
-@respx.mock
-def test_is_file_type_supported_caches_deployment_response(client: CompassClient, respx_mock: MockRouter):
-    route = respx_mock.get("http://test.com/v1/config/supported-file-types").mock(
-        return_value=httpx.Response(
-            200,
-            json={"file_types": [{"mime_types": ["audio/mpeg"], "extensions": [".mp3"]}]},
-        )
-    )
-
-    assert client.is_file_type_supported(filename="a.mp3") is True
-    assert client.is_file_type_supported(filename="b.mp3") is True
-    assert route.call_count == 1
-
-
-@respx.mock
 def test_get_index_details(client: CompassClient, respx_mock: MockRouter):
     route = respx_mock.get("http://test.com/v1/indexes/test_index").mock(
         return_value=httpx.Response(

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -87,6 +87,19 @@ def test_supports_uppercase_mime_type_returns_true(supported_file_types: Support
     assert supported_file_types.supports(mime_type="Application/PDF") is True
 
 
+def test_supports_advertised_mime_type_with_internal_capitals() -> None:
+    response = SupportedFileTypesResponse(
+        file_types=[
+            SupportedFileType(
+                mime_types=["application/vnd.ms-excel.sheet.macroEnabled.12"],
+                extensions=[".xlsm"],
+            )
+        ]
+    )
+    assert response.supports(mime_type="application/vnd.ms-excel.sheet.macroEnabled.12") is True
+    assert response.supports(mime_type="application/vnd.ms-excel.sheet.macroenabled.12") is True
+
+
 def test_supports_mime_only_format_returns_true(supported_file_types: SupportedFileTypesResponse) -> None:
     """Formats advertised without extensions are still matchable by MIME type."""
     assert supported_file_types.supports(mime_type="application/octet-stream") is True

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,26 +1,42 @@
-from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
+from cohere_compass.content_types import ParserCapability, supported_file_types
 
 
-def test_minimal_set_excludes_capability_gated_formats() -> None:
-    assert not any(mime_type.startswith(("audio/", "video/")) for mime_type in MINIMAL_SUPPORTED_FILE_TYPES.mime_types)
-    assert not {".mp3", ".wav", ".mp4", ".avi"} & MINIMAL_SUPPORTED_FILE_TYPES.extensions
+def test_supported_file_types_without_capabilities_excludes_gated_formats() -> None:
+    result = supported_file_types()
+    assert not any(mime_type.startswith(("audio/", "video/")) for mime_type in result.mime_types)
+    assert not {".mp3", ".wav", ".mp4", ".avi"} & result.extensions
 
 
-def test_minimal_set_accepts_ungated_formats() -> None:
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="report.pdf") is True
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="values.yml") is True
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="budget.xlsm") is True
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(mime_type="application/x-yaml") is True
+def test_supported_file_types_without_capabilities_accepts_ungated_formats() -> None:
+    result = supported_file_types()
+    assert result.supports(filename="report.pdf") is True
+    assert result.supports(filename="values.yml") is True
+    assert result.supports(filename="budget.xlsm") is True
+    assert result.supports(mime_type="application/x-yaml") is True
 
 
-def test_minimal_set_rejects_gated_and_unknown_formats() -> None:
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="interview.mp3") is False
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(mime_type="audio/mpeg") is False
-    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="archive.zip") is False
+def test_supported_file_types_without_capabilities_rejects_gated_and_unknown_formats() -> None:
+    result = supported_file_types()
+    assert result.supports(filename="interview.mp3") is False
+    assert result.supports(mime_type="audio/mpeg") is False
+    assert result.supports(filename="archive.zip") is False
 
 
-def test_minimal_set_accepts_every_type_it_advertises() -> None:
-    for mime_type in MINIMAL_SUPPORTED_FILE_TYPES.mime_types:
-        assert MINIMAL_SUPPORTED_FILE_TYPES.supports(mime_type=mime_type) is True
-    for extension in MINIMAL_SUPPORTED_FILE_TYPES.extensions:
-        assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename=f"document{extension}") is True
+def test_supported_file_types_with_asr_includes_audio_but_not_video() -> None:
+    result = supported_file_types([ParserCapability.ASR])
+    assert result.supports(filename="interview.mp3") is True
+    assert result.supports(filename="clip.mp4") is False
+
+
+def test_supported_file_types_with_asr_and_video_llm_includes_video() -> None:
+    result = supported_file_types([ParserCapability.ASR, ParserCapability.VIDEO_LLM])
+    assert result.supports(filename="interview.mp3") is True
+    assert result.supports(filename="clip.mp4") is True
+
+
+def test_supported_file_types_accepts_every_type_it_advertises() -> None:
+    result = supported_file_types()
+    for mime_type in result.mime_types:
+        assert result.supports(mime_type=mime_type) is True
+    for extension in result.extensions:
+        assert result.supports(filename=f"document{extension}") is True

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,0 +1,26 @@
+from cohere_compass.content_types import MINIMAL_SUPPORTED_FILE_TYPES
+
+
+def test_minimal_set_excludes_capability_gated_formats() -> None:
+    assert not any(mime_type.startswith(("audio/", "video/")) for mime_type in MINIMAL_SUPPORTED_FILE_TYPES.mime_types)
+    assert not {".mp3", ".wav", ".mp4", ".avi"} & MINIMAL_SUPPORTED_FILE_TYPES.extensions
+
+
+def test_minimal_set_accepts_ungated_formats() -> None:
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="report.pdf") is True
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="values.yml") is True
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="budget.xlsm") is True
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(mime_type="application/x-yaml") is True
+
+
+def test_minimal_set_rejects_gated_and_unknown_formats() -> None:
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="interview.mp3") is False
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(mime_type="audio/mpeg") is False
+    assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename="archive.zip") is False
+
+
+def test_minimal_set_accepts_every_type_it_advertises() -> None:
+    for mime_type in MINIMAL_SUPPORTED_FILE_TYPES.mime_types:
+        assert MINIMAL_SUPPORTED_FILE_TYPES.supports(mime_type=mime_type) is True
+    for extension in MINIMAL_SUPPORTED_FILE_TYPES.extensions:
+        assert MINIMAL_SUPPORTED_FILE_TYPES.supports(filename=f"document{extension}") is True


### PR DESCRIPTION
## Summary
- `get_supported_file_types()` takes an optional `capabilities` list (`ParserCapability.ASR`, `ParserCapability.VIDEO_LLM`), defaulting to empty.
- On network failure or a missing endpoint, the local set is built from that list: empty omits audio and video; known backends include the formats they unlock.
- Check a file with `get_supported_file_types(...).supports(filename=...)`.

## Test plan
- [ ] `poetry run pytest tests/test_content_types.py tests/test_config_models.py tests/test_compass_client.py -k supported_file`
- [ ] Confirm a 404 or timeout returns the empty-capability set (no audio/video)
- [ ] Confirm `capabilities=[ParserCapability.ASR]` on fallback includes mp3 but not mp4
- [ ] Confirm `fallback_on_failure=False` still raises on 404, and 401 is not swallowed